### PR TITLE
fix: add missing requirements for crates.io publishing

### DIFF
--- a/crates/redis-cloud/README.md
+++ b/crates/redis-cloud/README.md
@@ -1,0 +1,76 @@
+# redis-cloud
+
+A comprehensive Rust client library for the Redis Cloud REST API.
+
+## Features
+
+- Complete coverage of Redis Cloud REST API endpoints
+- Async/await support with tokio
+- Strong typing for API requests and responses
+- Comprehensive error handling
+- Support for all Redis Cloud features including:
+  - Subscriptions and databases
+  - User and ACL management
+  - Backup and restore operations
+  - VPC peering and networking
+  - Metrics and monitoring
+  - Billing and payment management
+
+## Installation
+
+```toml
+[dependencies]
+redis-cloud = "0.1.0"
+```
+
+## Usage
+
+```rust
+use redis_cloud::{CloudClient, CloudClientConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = CloudClientConfig {
+        api_key: "your-api-key".to_string(),
+        secret_key: "your-secret-key".to_string(),
+        base_url: None, // Uses default https://api.redislabs.com/v1
+    };
+
+    let client = CloudClient::new(config)?;
+    
+    // List all subscriptions
+    let subscriptions = client.list_subscriptions(None).await?;
+    println!("Subscriptions: {:?}", subscriptions);
+    
+    // Get account information
+    let account = client.get_account().await?;
+    println!("Account: {:?}", account);
+    
+    Ok(())
+}
+```
+
+## API Coverage
+
+This library provides comprehensive coverage of the Redis Cloud REST API, including:
+
+- **Account Management** - Account info, users, payment methods
+- **Subscriptions** - CRUD operations, pricing, CIDR management
+- **Databases** - Full database lifecycle, backups, imports, metrics
+- **ACL Management** - Users, roles, Redis rules
+- **Networking** - VPC peering, Transit Gateway, Private Service Connect
+- **Monitoring** - Metrics, logs, alerts
+- **Billing** - Invoices, payment methods, usage
+
+## Documentation
+
+For detailed API documentation, see the [Redis Cloud API Reference](https://api.redislabs.com/v1/swagger-ui/index.html).
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/crates/redis-enterprise/README.md
+++ b/crates/redis-enterprise/README.md
@@ -1,0 +1,83 @@
+# redis-enterprise
+
+A comprehensive Rust client library for the Redis Enterprise REST API.
+
+## Features
+
+- Complete coverage of Redis Enterprise REST API endpoints
+- Async/await support with tokio
+- Strong typing for API requests and responses
+- Comprehensive error handling
+- Support for all Redis Enterprise features including:
+  - Cluster management and bootstrap
+  - Database (BDB) operations
+  - Node management and statistics
+  - User and role management
+  - Redis modules
+  - Active-Active (CRDB) databases
+  - Monitoring and alerts
+
+## Installation
+
+```toml
+[dependencies]
+redis-enterprise = "0.1.0"
+```
+
+## Usage
+
+```rust
+use redis_enterprise::{EnterpriseClient, EnterpriseClientConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = EnterpriseClientConfig {
+        base_url: "https://cluster.example.com:9443".to_string(),
+        username: "admin@example.com".to_string(),
+        password: "your-password".to_string(),
+        insecure: false, // Set to true for self-signed certificates
+    };
+
+    let client = EnterpriseClient::new(config)?;
+    
+    // Get cluster information
+    let cluster = client.get_cluster_info().await?;
+    println!("Cluster: {:?}", cluster);
+    
+    // List databases
+    let databases = client.list_databases().await?;
+    println!("Databases: {:?}", databases);
+    
+    // Get node statistics
+    let stats = client.get_node_stats("1").await?;
+    println!("Node stats: {:?}", stats);
+    
+    Ok(())
+}
+```
+
+## API Coverage
+
+This library provides 100% coverage of the Redis Enterprise REST API, including:
+
+- **Cluster Operations** - Bootstrap, configuration, topology
+- **Database Management** - CRUD operations, actions, statistics
+- **Node Management** - Add/remove nodes, statistics, actions
+- **Security** - Users, roles, ACLs, LDAP integration
+- **Modules** - Upload and manage Redis modules
+- **Monitoring** - Stats, alerts, logs, diagnostics
+- **Active-Active** - CRDB management and tasks
+- **Administration** - License, certificates, services
+
+## Documentation
+
+For detailed API documentation, see the [Redis Enterprise REST API Reference](https://docs.redis.com/latest/rs/references/rest-api/).
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -26,9 +26,9 @@ path = "src/enterprise_bin.rs"
 required-features = ["enterprise-only"]
 
 [dependencies]
-redis-common = { path = "../redis-common" }
-redis-cloud = { path = "../redis-cloud" }
-redis-enterprise = { path = "../redis-enterprise" }
+redis-common = { version = "0.1.0", path = "../redis-common" }
+redis-cloud = { version = "0.1.0", path = "../redis-cloud" }
+redis-enterprise = { version = "0.1.0", path = "../redis-enterprise" }
 
 # CLI dependencies
 clap = { workspace = true }


### PR DESCRIPTION
## Summary
Add the missing pieces needed for successful crates.io publishing:
- README.md files for library crates (redis-cloud and redis-enterprise)  
- Version numbers for internal dependencies in redisctl's Cargo.toml

## Context
Release-plz was already added to main, but these requirements were missing and would cause publishing to fail.

## Testing
- Verified with `cargo publish --dry-run` for each crate
- Correct dependency ordering confirmed

Once merged, release-plz will be able to successfully publish all crates to crates.io.