### PR TITLE
fix: remove CLAUDE.md from .gitignore to fix release-plz CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,4 @@ lcov.info
 dump.rdb
 
 # Claude
-CLAUDE.md
 .claude/


### PR DESCRIPTION
## Problem
Release-plz CI was failing with:
```
the working directory of this project has uncommitted changes...CLAUDE.md
```

## Root Cause
CLAUDE.md was both:
1. Committed to the repository 
2. Listed in .gitignore

This confuses release-plz as it sees the file as having uncommitted changes.

## Solution
Remove CLAUDE.md from .gitignore since we want it tracked in the repo.

## Testing
After this change, release-plz should run successfully in CI.