### PR TITLE
fix: security workflow missing toolchain parameter

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,8 @@ jobs:
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a  # stable
+        with:
+          toolchain: stable
       
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab  # v2.7.5
@@ -89,7 +91,6 @@ print(json.dumps(sarif))
         with:
           command: check
           arguments: --all-features
-        continue-on-error: true  # Don't fail until deny.toml is configured
 
   dependency-review:
     name: Dependency Review


### PR DESCRIPTION
## Problem
The security workflow is failing immediately with a workflow file parsing error.

## Root Cause
The `dtolnay/rust-toolchain` action is missing the required `toolchain: stable` parameter, causing the workflow to fail during parsing.

## Fix
- Added `toolchain: stable` parameter to the rust-toolchain action
- Removed `continue-on-error` from cargo-deny since deny.toml is now properly configured

## Testing
This fix is identical to what was applied to the CI workflow and should resolve the immediate failure.