### PR TITLE
fix: correct cargo-dist workflow tag pattern for binary builds

### DIFF
--- a/.github/workflows/redisctl-release.yml
+++ b/.github/workflows/redisctl-release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - 'redisctl**[0-9]+.[0-9]+.[0-9]+*'
+      - 'redisctl-v*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do


### PR DESCRIPTION
The cargo-dist workflow wasn't triggering on our releases because the tag pattern was incorrect.

## Problem
- Pattern was: `'redisctl**[0-9]+.[0-9]+.[0-9]+*'`
- Our tags are: `redisctl-v0.2.0`
- The `**` should have been `-v`

## Solution
Changed pattern to `'redisctl-v*'` to properly match our release tags.

This will ensure that future releases trigger cargo-dist to build binaries for all platforms.