### PR TITLE
fix: re-enable mdbook-lint with version 0.11.5

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -35,6 +35,27 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache mdbook-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/mdbook-lint
+          key: mdbook-lint-0.11.5-${{ runner.os }}
+
+      - name: Install mdbook-lint 0.11.5
+        run: |
+          if ! command -v mdbook-lint || [ "$(mdbook-lint --version | cut -d' ' -f2)" != "0.11.5" ]; then
+            cargo install mdbook-lint --version 0.11.5 --locked
+          fi
+
+      - name: Lint book
+        run: |
+          cd docs
+          mdbook-lint lint src
 
       - name: Build book
         run: |


### PR DESCRIPTION
## Summary
Re-enables mdbook-lint in the documentation workflow using the newly released version 0.11.5 which fixes the false positive issues we were experiencing.

## Changes
- Install specific version 0.11.5 with --locked flag for consistency
- Add Rust toolchain setup for cargo install
- Cache mdbook-lint binary to speed up CI runs
- Lint runs but doesn't fail CI due to existing fail-on-warnings=false config

## Testing
- Tested locally with mdbook-lint 0.11.5
- Linter runs successfully and reports warnings but doesn't fail
- No more false positives about unclosed math blocks in shell examples

Fixes #37