### PR TITLE
chore: update mdbook-lint config to correct syntax

### DIFF
--- a/docs/.mdbook-lint.toml
+++ b/docs/.mdbook-lint.toml
@@ -13,42 +13,42 @@ fail-on-warnings = false
 fail-on-errors = false
 
 # Enable rules that should be fixable
-[rules.MD022]
+[MD022]
 # Require blank lines around headings 
 enabled = true
 
-[rules.MD032]
+[MD032]
 # Require blank lines around lists
 enabled = true
 
-[rules.MD031]
+[MD031]
 # Require blank lines around fenced code blocks
 enabled = true
 
-[rules.MD006]
+[MD006]
 # Lists should start at beginning of line
 enabled = true
 
-[rules.MD047]
+[MD047]
 # Files should end with single newline
 enabled = true
 
 # Configure specific rules
-[rules.MD013]
+[MD013]
 # Allow longer lines for code examples and CLI output
 line_length = 120
 
-[rules.MD024]
+[MD024]
 # Allow duplicate headings in different sections
 enabled = true
 
-[rules.MD041]
+[MD041]
 # Require first line to be a heading
 enabled = true
 
 # Future configuration options when issues are resolved:
-# [rules.MDBOOK005]
+# [MDBOOK005]
 # search-path = "src"  # Only check within src directory
 # 
-# [rules.MDBOOK010]  
+# [MDBOOK010]  
 # skip-code-blocks = true  # Skip math detection in code blocks


### PR DESCRIPTION
## Summary
Updates mdbook-lint configuration to use the correct syntax as fixed in v0.11.5.

## Changes
- Update rule configuration from `[rules.MD*]` to `[MD*]` format
- This fixes the configuration syntax that was incorrect in 130+ documentation examples (per v0.11.5 release notes)

## Context
- mdbook-lint v0.11.5 corrected the documentation to show the proper configuration format
- Our config was using the old incorrect format from the documentation
- This ensures our configuration will work correctly with current and future versions

## Related
- Follows up on PR #56 which re-enabled mdbook-lint
- References the release automation guide now at: https://gist.github.com/joshrotenberg/ccccfbe5a5712255fd7b0c21c8877047