### PR TITLE
fix: standardize redis-cloud handler naming for consistency

### DIFF
--- a/crates/redis-cloud/src/handlers/account.rs
+++ b/crates/redis-cloud/src/handlers/account.rs
@@ -23,6 +23,11 @@ impl CloudAccountHandler {
         Ok(response.account)
     }
 
+    /// Get current account information (alias for info())
+    pub async fn get(&self) -> Result<CloudAccount> {
+        self.info().await
+    }
+
     /// Get account owner information
     pub async fn owner(&self) -> Result<Value> {
         self.client.get("/users/owners").await

--- a/crates/redis-cloud/src/handlers/api_keys.rs
+++ b/crates/redis-cloud/src/handlers/api_keys.rs
@@ -3,14 +3,14 @@
 use crate::{Result, client::CloudClient};
 use serde_json::Value;
 
-/// Handler for Cloud API keys management
-pub struct CloudApiKeysHandler {
+/// Handler for Cloud API key management
+pub struct CloudApiKeyHandler {
     client: CloudClient,
 }
 
-impl CloudApiKeysHandler {
+impl CloudApiKeyHandler {
     pub fn new(client: CloudClient) -> Self {
-        CloudApiKeysHandler { client }
+        CloudApiKeyHandler { client }
     }
 
     /// List all API keys

--- a/crates/redis-cloud/src/handlers/mod.rs
+++ b/crates/redis-cloud/src/handlers/mod.rs
@@ -23,7 +23,7 @@ pub mod users;
 // Re-export all handlers
 pub use account::CloudAccountHandler;
 pub use acl::CloudAclHandler;
-pub use api_keys::CloudApiKeysHandler;
+pub use api_keys::CloudApiKeyHandler;
 pub use backup::CloudBackupHandler;
 pub use billing::CloudBillingHandler;
 pub use cloud_accounts::CloudAccountsHandler;
@@ -37,6 +37,6 @@ pub use private_service_connect::CloudPrivateServiceConnectHandler;
 pub use region::CloudRegionHandler;
 pub use sso::CloudSsoHandler;
 pub use subscription::CloudSubscriptionHandler;
-pub use tasks::CloudTasksHandler;
+pub use tasks::CloudTaskHandler;
 pub use transit_gateway::CloudTransitGatewayHandler;
-pub use users::CloudUsersHandler;
+pub use users::CloudUserHandler;

--- a/crates/redis-cloud/src/handlers/tasks.rs
+++ b/crates/redis-cloud/src/handlers/tasks.rs
@@ -4,13 +4,13 @@ use crate::{Result, client::CloudClient};
 use serde_json::Value;
 
 /// Handler for Cloud task operations
-pub struct CloudTasksHandler {
+pub struct CloudTaskHandler {
     client: CloudClient,
 }
 
-impl CloudTasksHandler {
+impl CloudTaskHandler {
     pub fn new(client: CloudClient) -> Self {
-        CloudTasksHandler { client }
+        CloudTaskHandler { client }
     }
 
     /// List all tasks

--- a/crates/redis-cloud/src/handlers/users.rs
+++ b/crates/redis-cloud/src/handlers/users.rs
@@ -4,13 +4,13 @@ use crate::{Result, client::CloudClient};
 use serde_json::Value;
 
 /// Handler for Cloud user operations
-pub struct CloudUsersHandler {
+pub struct CloudUserHandler {
     client: CloudClient,
 }
 
-impl CloudUsersHandler {
+impl CloudUserHandler {
     pub fn new(client: CloudClient) -> Self {
-        CloudUsersHandler { client }
+        CloudUserHandler { client }
     }
 
     /// List all users

--- a/crates/redis-cloud/src/lib.rs
+++ b/crates/redis-cloud/src/lib.rs
@@ -211,7 +211,7 @@
 //! | [`CloudSubscriptionHandler`] | Subscription management | create, list, update, delete, pricing |
 //! | [`CloudDatabaseHandler`] | Database operations | create, backup, import, metrics, resize |
 //! | [`CloudAccountHandler`] | Account information | info, users, payment methods |
-//! | [`CloudUsersHandler`] | User management | create, update, delete, invite |
+//! | [`CloudUserHandler`] | User management | create, update, delete, invite |
 //! | [`CloudBillingHandler`] | Billing & payments | invoices, payment methods, usage reports |
 //! | [`CloudBackupHandler`] | Database backups | create, restore, list, delete |
 //! | [`CloudAclHandler`] | Access control | users, roles, Redis rules |
@@ -219,7 +219,7 @@
 //! | [`CloudSsoHandler`] | SSO/SAML | configure, test, user/group mappings |
 //! | [`CloudMetricsHandler`] | Monitoring | database and subscription metrics |
 //! | [`CloudLogsHandler`] | Audit trails | system, database, and session logs |
-//! | [`CloudTasksHandler`] | Async operations | track long-running operations |
+//! | [`CloudTaskHandler`] | Async operations | track long-running operations |
 //!
 //! ## Authentication
 //!
@@ -241,11 +241,11 @@ pub use client::{CloudClient, CloudClientBuilder};
 
 // Re-export handlers explicitly
 pub use handlers::{
-    CloudAccountHandler, CloudAccountsHandler, CloudAclHandler, CloudApiKeysHandler,
+    CloudAccountHandler, CloudAccountsHandler, CloudAclHandler, CloudApiKeyHandler,
     CloudBackupHandler, CloudBillingHandler, CloudCrdbHandler, CloudDatabaseHandler,
     CloudFixedHandler, CloudLogsHandler, CloudMetricsHandler, CloudPeeringHandler,
     CloudPrivateServiceConnectHandler, CloudRegionHandler, CloudSsoHandler,
-    CloudSubscriptionHandler, CloudTasksHandler, CloudTransitGatewayHandler, CloudUsersHandler,
+    CloudSubscriptionHandler, CloudTaskHandler, CloudTransitGatewayHandler, CloudUserHandler,
 };
 
 // Re-export models explicitly

--- a/crates/redis-cloud/tests/api_keys_tests.rs
+++ b/crates/redis-cloud/tests/api_keys_tests.rs
@@ -1,6 +1,6 @@
 //! API keys endpoint tests for Redis Cloud
 
-use redis_cloud::{CloudApiKeysHandler, CloudClient};
+use redis_cloud::{CloudApiKeyHandler, CloudClient};
 use serde_json::json;
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -61,7 +61,7 @@ async fn test_list_api_keys() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.list().await;
 
     assert!(result.is_ok());
@@ -94,7 +94,7 @@ async fn test_list_api_keys_error() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.list().await;
 
     assert!(result.is_err());
@@ -124,7 +124,7 @@ async fn test_get_api_key() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.get(1001).await;
 
     assert!(result.is_ok());
@@ -157,7 +157,7 @@ async fn test_get_api_key_not_found() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.get(9999).await;
 
     assert!(result.is_err());
@@ -186,7 +186,7 @@ async fn test_create_api_key() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let request = json!({
         "name": "Test API Key",
         "permissions": ["read"],
@@ -226,7 +226,7 @@ async fn test_update_api_key() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let request = json!({
         "name": "Updated Production API Key",
         "description": "Updated description"
@@ -253,7 +253,7 @@ async fn test_delete_api_key() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.delete(1001).await;
 
     assert!(result.is_ok());
@@ -282,7 +282,7 @@ async fn test_regenerate_api_key() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.regenerate(1001).await;
 
     assert!(result.is_ok());
@@ -322,7 +322,7 @@ async fn test_get_permissions() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.get_permissions(1001).await;
 
     assert!(result.is_ok());
@@ -358,7 +358,7 @@ async fn test_update_permissions() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let request = json!({
         "resources": [
             {
@@ -397,7 +397,7 @@ async fn test_enable_api_key() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.enable(1001).await;
 
     assert!(result.is_ok());
@@ -426,7 +426,7 @@ async fn test_disable_api_key() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.disable(1001).await;
 
     assert!(result.is_ok());
@@ -473,7 +473,7 @@ async fn test_get_usage() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.get_usage(1001, "30d").await;
 
     assert!(result.is_ok());
@@ -522,7 +522,7 @@ async fn test_get_audit_logs() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.get_audit_logs(1001).await;
 
     assert!(result.is_ok());
@@ -555,7 +555,7 @@ async fn test_get_audit_logs_error() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudApiKeysHandler::new(client);
+    let handler = CloudApiKeyHandler::new(client);
     let result = handler.get_audit_logs(1001).await;
 
     assert!(result.is_err());

--- a/crates/redis-cloud/tests/tasks_tests.rs
+++ b/crates/redis-cloud/tests/tasks_tests.rs
@@ -1,6 +1,6 @@
 //! Tasks endpoint tests for Redis Cloud
 
-use redis_cloud::{CloudClient, CloudTasksHandler};
+use redis_cloud::{CloudClient, CloudTaskHandler};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -181,7 +181,7 @@ async fn test_list_tasks() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.list().await;
 
@@ -236,7 +236,7 @@ async fn test_list_tasks_empty() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.list().await;
 
@@ -274,7 +274,7 @@ async fn test_list_tasks_unauthorized() {
         .base_url(mock_server.uri())
         .build()
         .unwrap();
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.list().await;
 
@@ -294,7 +294,7 @@ async fn test_get_task_processing() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.get("task_12345").await;
 
@@ -338,7 +338,7 @@ async fn test_get_task_completed() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.get("task_completed").await;
 
@@ -372,7 +372,7 @@ async fn test_get_task_failed() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.get("task_failed").await;
 
@@ -418,7 +418,7 @@ async fn test_get_task_not_found() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.get("nonexistent_task").await;
 
@@ -447,7 +447,7 @@ async fn test_get_task_invalid_id_format() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.get("invalid-task-id").await;
 
@@ -467,7 +467,7 @@ async fn test_get_task_with_special_characters() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.get("task_abc-123_xyz").await;
 
@@ -496,7 +496,7 @@ async fn test_get_task_forbidden() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudTasksHandler::new(client);
+    let handler = CloudTaskHandler::new(client);
 
     let result = handler.get("task_restricted").await;
 

--- a/crates/redis-cloud/tests/users_tests.rs
+++ b/crates/redis-cloud/tests/users_tests.rs
@@ -1,6 +1,6 @@
 //! Users endpoint tests for Redis Cloud
 
-use redis_cloud::{CloudClient, CloudUsersHandler};
+use redis_cloud::{CloudClient, CloudUserHandler};
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -75,7 +75,7 @@ async fn test_users_list() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.list().await;
 
     assert!(result.is_ok());
@@ -113,7 +113,7 @@ async fn test_users_list_empty() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.list().await;
 
     assert!(result.is_ok());
@@ -147,7 +147,7 @@ async fn test_user_get() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.get(1).await;
 
     assert!(result.is_ok());
@@ -196,7 +196,7 @@ async fn test_user_create_invite() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.create(request_body).await;
 
     assert!(result.is_ok());
@@ -238,7 +238,7 @@ async fn test_user_create_admin() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.create(request_body).await;
 
     assert!(result.is_ok());
@@ -276,7 +276,7 @@ async fn test_user_update() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.update(1, request_body).await;
 
     assert!(result.is_ok());
@@ -302,7 +302,7 @@ async fn test_user_delete() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.delete(2).await;
 
     assert!(result.is_ok());
@@ -338,7 +338,7 @@ async fn test_users_list_unauthorized() {
         .base_url(mock_server.uri())
         .build()
         .unwrap();
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.list().await;
 
     assert!(result.is_err());
@@ -366,7 +366,7 @@ async fn test_user_get_not_found() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.get(999).await;
 
     assert!(result.is_err());
@@ -403,7 +403,7 @@ async fn test_user_create_invalid_email() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.create(request_body).await;
 
     assert!(result.is_err());
@@ -437,7 +437,7 @@ async fn test_user_create_duplicate_email() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.create(request_body).await;
 
     assert!(result.is_err());
@@ -469,7 +469,7 @@ async fn test_user_update_insufficient_permissions() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.update(1, request_body).await;
 
     assert!(result.is_err());
@@ -497,7 +497,7 @@ async fn test_user_delete_last_owner() {
         .await;
 
     let client = create_test_client(mock_server.uri());
-    let handler = CloudUsersHandler::new(client);
+    let handler = CloudUserHandler::new(client);
     let result = handler.delete(1).await;
 
     assert!(result.is_err());

--- a/crates/redisctl/src/commands/cloud.rs
+++ b/crates/redisctl/src/commands/cloud.rs
@@ -346,13 +346,13 @@ pub async fn handle_user_command(
 
     match command {
         UserCommands::List => {
-            let handler = redis_cloud::CloudUsersHandler::new(client.clone());
+            let handler = redis_cloud::CloudUserHandler::new(client.clone());
             let users = handler.list().await?;
             let value = serde_json::to_value(users)?;
             print_output(value, output_format, query)?;
         }
         UserCommands::Show { id } => {
-            let handler = redis_cloud::CloudUsersHandler::new(client.clone());
+            let handler = redis_cloud::CloudUserHandler::new(client.clone());
             let user = handler.get(id.parse()?).await?;
             let value = serde_json::to_value(user)?;
             print_output(value, output_format, query)?;
@@ -363,7 +363,7 @@ pub async fn handle_user_command(
             password,
             roles,
         } => {
-            let handler = redis_cloud::CloudUsersHandler::new(client.clone());
+            let handler = redis_cloud::CloudUserHandler::new(client.clone());
             let mut create_data = serde_json::json!({
                 "name": name
             });
@@ -388,7 +388,7 @@ pub async fn handle_user_command(
             email,
             password,
         } => {
-            let handler = redis_cloud::CloudUsersHandler::new(client.clone());
+            let handler = redis_cloud::CloudUserHandler::new(client.clone());
             let mut update_data = serde_json::Map::new();
             if let Some(email) = email {
                 update_data.insert("email".to_string(), serde_json::Value::String(email));
@@ -412,7 +412,7 @@ pub async fn handle_user_command(
                 );
                 return Ok(());
             }
-            let handler = redis_cloud::CloudUsersHandler::new(client.clone());
+            let handler = redis_cloud::CloudUserHandler::new(client.clone());
             handler.delete(id.parse()?).await?;
             println!("User {} deleted successfully", id);
         }
@@ -451,13 +451,13 @@ pub async fn handle_task_command(
 
     match command {
         TaskCommands::List => {
-            let handler = redis_cloud::CloudTasksHandler::new(client.clone());
+            let handler = redis_cloud::CloudTaskHandler::new(client.clone());
             let tasks = handler.list().await?;
             let value = serde_json::to_value(tasks)?;
             print_output(value, output_format, query)?;
         }
         TaskCommands::Show { id } => {
-            let handler = redis_cloud::CloudTasksHandler::new(client.clone());
+            let handler = redis_cloud::CloudTaskHandler::new(client.clone());
             let task = handler.get(&id).await?;
             let value = serde_json::to_value(task)?;
             print_output(value, output_format, query)?;
@@ -470,7 +470,7 @@ pub async fn handle_task_command(
             let timeout_duration = Duration::from_secs(timeout);
 
             loop {
-                let handler = redis_cloud::CloudTasksHandler::new(client.clone());
+                let handler = redis_cloud::CloudTaskHandler::new(client.clone());
                 let task = handler.get(&id).await?;
                 let task = serde_json::to_value(task)?;
 
@@ -915,17 +915,17 @@ pub async fn handle_api_key_command(
 
     match command {
         ApiKeyCommands::List => {
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             let keys = handler.list().await?;
             print_output(keys, output_format, query)?;
         }
         ApiKeyCommands::Show { key_id } => {
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             let key = handler.get(key_id).await?;
             print_output(key, output_format, query)?;
         }
         ApiKeyCommands::Create { name, role } => {
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             let create_data = serde_json::json!({
                 "name": name,
                 "role": role
@@ -941,7 +941,7 @@ pub async fn handle_api_key_command(
             if let Some(role) = role {
                 update_data.insert("role".to_string(), serde_json::Value::String(role));
             }
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             let key = handler
                 .update(key_id, serde_json::Value::Object(update_data))
                 .await?;
@@ -955,22 +955,22 @@ pub async fn handle_api_key_command(
                 );
                 return Ok(());
             }
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             handler.delete(key_id).await?;
             println!("API key {} deleted successfully", key_id);
         }
         ApiKeyCommands::Regenerate { key_id } => {
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             let result = handler.regenerate(key_id).await?;
             print_output(result, output_format, query)?;
         }
         ApiKeyCommands::Enable { key_id } => {
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             let result = handler.enable(key_id).await?;
             print_output(result, output_format, query)?;
         }
         ApiKeyCommands::Disable { key_id } => {
-            let handler = redis_cloud::CloudApiKeysHandler::new(client.clone());
+            let handler = redis_cloud::CloudApiKeyHandler::new(client.clone());
             let result = handler.disable(key_id).await?;
             print_output(result, output_format, query)?;
         }


### PR DESCRIPTION
## Summary
Brings redis-cloud crate to the same consistency standard as redis-enterprise by standardizing handler naming and adding convenience methods.

## Changes
- **Handler Naming**: Standardized to singular form for consistency
  - `CloudUsersHandler` → `CloudUserHandler`
  - `CloudApiKeysHandler` → `CloudApiKeyHandler`
  - `CloudTasksHandler` → `CloudTaskHandler`
  - Note: `CloudAccountsHandler` kept as-is (different from `CloudAccountHandler` - they handle different endpoints)

- **Convenience Methods**: 
  - Added `get()` as alias for `info()` in `CloudAccountHandler`

- **Test Updates**: Updated all test files to use new handler names

- **CLI Updates**: Updated command handlers to use new names

## Test Plan
- [x] All tests pass
- [x] cargo fmt passes
- [x] cargo clippy passes
- [x] No breaking changes to request/response types

## Notes
- No backwards compatibility aliases added per user preference (we don't have users yet)
- This brings redis-cloud to the same standard as redis-enterprise after PR #66

Closes #67
Closes #62