### PR TITLE
refactor: minor CLI consistency improvement

### DIFF
--- a/crates/redisctl/src/commands/cloud.rs
+++ b/crates/redisctl/src/commands/cloud.rs
@@ -312,7 +312,7 @@ pub async fn handle_account_command(
         }
         AccountCommands::Info => {
             let handler = redis_cloud::CloudAccountHandler::new(client.clone());
-            let account_info = handler.info().await?;
+            let account_info = handler.get().await?;
             let value = serde_json::to_value(account_info)?;
             print_output(value, output_format, query)?;
         }


### PR DESCRIPTION
## Summary
Small consistency improvement in the CLI to use the convenience method we added in previous PRs.

## Changes
- Use `get()` instead of `info()` for CloudAccountHandler (we added `get()` as an alias in PR #69)
- This makes the API usage more consistent across handlers

## Test Plan
- [x] All tests pass
- [x] cargo fmt passes
- [x] cargo clippy passes

## Notes
This is a very minor change that improves consistency. The functionality is identical since `get()` just calls `info()` internally.