### PR TITLE
feat(cloud): audit + typed-only refactor to 100% OpenAPI coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository Guidelines
 
+Use this guide to contribute effectively to this repository. Keep changes focused, tested, and consistent with the existing style.
+
 ## Project Structure & Module Organization
 - `crates/redisctl/`: CLI binary (`src/main.rs`) and command handlers.
 - `crates/redis-cloud/`: Rust client for Redis Cloud REST API.
@@ -14,28 +16,25 @@
 - Lint (deny warnings): `cargo clippy --all-targets --all-features -- -D warnings`
 - Format check: `cargo fmt --all -- --check`
 - Install CLI from source: `cargo install --path crates/redisctl`
-- Docs (mdBook): `cd docs && mdbook build` (serve locally: `mdbook serve`)
+- Docs: `cd docs && mdbook build` (serve locally: `mdbook serve`)
 - Local Enterprise env: `docker compose up -d` (cleanup: `docker compose down -v`)
 
 ## Coding Style & Naming Conventions
-- Rust 2024 edition, MSRV: 1.89.
-- Use `rustfmt` defaults; run `cargo fmt --all` before pushing.
-- Naming: types/traits = `CamelCase`; functions/modules/files = `snake_case`; feature flags = `kebab-case` (`cloud`, `enterprise`, `full`).
-- Prefer explicit errors via `thiserror` and `anyhow::Context`.
-- Tracing: initialize via `tracing_subscriber::fmt::init()` in binaries.
+- Rust 2024 edition; MSRV: 1.89. Run `cargo fmt --all` before pushing.
+- Names: types/traits = CamelCase; functions/modules/files = snake_case; feature flags = kebab-case (`cloud`, `enterprise`, `full`).
+- Errors: prefer explicit types via `thiserror`; add context with `anyhow::Context`.
+- Tracing: binaries should initialize logging with `tracing_subscriber::fmt::init()`.
 
 ## Testing Guidelines
-- Unit tests live next to code; integration tests under `tests/integration`.
-- Mock HTTP with `wiremock`; prefer async tests using `tokio::test`.
-- Add tests for new commands and API paths; cover both success and error cases.
-- Run full suite and clippy locally before opening a PR.
+- Unit tests live next to code; integration tests in `tests/integration`.
+- Prefer async tests with `#[tokio::test]`; mock HTTP using `wiremock`.
+- Add tests for new commands and API paths; cover success and error cases.
+- Before a PR, run: `cargo test --workspace --all-features` and clippy/fmt commands above.
 
 ## Commit & Pull Request Guidelines
-- Conventional commits (used by tooling and changelogs):
-  - Examples: `feat: add cluster status command`, `fix: handle 401 in cloud client`, `docs: update install steps`.
-- PRs should include: clear description, linked issues, test updates, and docs/help text when user-facing.
-- Keep changes focused; avoid unrelated refactors. Ensure CI green.
+- Use Conventional Commits (e.g., `feat: add cluster status command`, `fix: handle 401 in cloud client`, `docs: update install steps`).
+- PRs must include: clear description, linked issues, updated tests, and docs/help text for user-facing changes. Keep changes scoped; ensure CI is green.
 
 ## Security & Configuration Tips
-- Never commit secrets. Use env vars (e.g., `REDIS_CLOUD_API_KEY`, `REDIS_ENTERPRISE_PASSWORD`).
-- Use `scripts/install-hooks.sh` to install pre-commit hooks (fmt, clippy, tests).
+- Never commit secrets. Use env vars like `REDIS_CLOUD_API_KEY` and `REDIS_ENTERPRISE_PASSWORD`.
+- Install pre-commit hooks: `scripts/install-hooks.sh` (runs fmt, clippy, tests).

--- a/crates/redis-enterprise/src/actions.rs
+++ b/crates/redis-enterprise/src/actions.rs
@@ -49,4 +49,23 @@ impl ActionHandler {
             .delete(&format!("/v1/actions/{}", action_uid))
             .await
     }
+
+    /// List actions via v2 API - GET /v2/actions (raw)
+    pub async fn list_v2_raw(&self) -> Result<Value> {
+        self.client.get("/v2/actions").await
+    }
+
+    /// Get action via v2 API - GET /v2/actions/{uid} (raw)
+    pub async fn get_v2_raw(&self, action_uid: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v2/actions/{}", action_uid))
+            .await
+    }
+
+    /// List actions for a database - GET /v1/actions/bdb/{uid} (raw)
+    pub async fn list_for_bdb_raw(&self, bdb_uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/actions/bdb/{}", bdb_uid))
+            .await
+    }
 }

--- a/crates/redis-enterprise/src/actions.rs
+++ b/crates/redis-enterprise/src/actions.rs
@@ -1,4 +1,8 @@
 //! Action management for Redis Enterprise async operations
+//!
+//! Overview
+//! - Track async tasks across the cluster
+//! - v1 and v2 endpoints exposed via `v1()` and `v2()` accessors
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/actions.rs
+++ b/crates/redis-enterprise/src/actions.rs
@@ -68,4 +68,75 @@ impl ActionHandler {
             .get(&format!("/v1/actions/bdb/{}", bdb_uid))
             .await
     }
+
+    // Versioned sub-handlers for clearer API
+    pub fn v1(&self) -> v1::ActionsV1 {
+        v1::ActionsV1::new(self.client.clone())
+    }
+
+    pub fn v2(&self) -> v2::ActionsV2 {
+        v2::ActionsV2::new(self.client.clone())
+    }
+}
+
+pub mod v1 {
+    use super::{Action, RestClient};
+    use crate::error::Result;
+
+    pub struct ActionsV1 {
+        client: RestClient,
+    }
+
+    impl ActionsV1 {
+        pub(crate) fn new(client: RestClient) -> Self {
+            Self { client }
+        }
+
+        pub async fn list(&self) -> Result<Vec<Action>> {
+            self.client.get("/v1/actions").await
+        }
+
+        pub async fn get(&self, action_uid: &str) -> Result<Action> {
+            self.client
+                .get(&format!("/v1/actions/{}", action_uid))
+                .await
+        }
+
+        pub async fn cancel(&self, action_uid: &str) -> Result<()> {
+            self.client
+                .delete(&format!("/v1/actions/{}", action_uid))
+                .await
+        }
+
+        pub async fn list_for_bdb(&self, bdb_uid: u32) -> Result<Vec<Action>> {
+            self.client
+                .get(&format!("/v1/actions/bdb/{}", bdb_uid))
+                .await
+        }
+    }
+}
+
+pub mod v2 {
+    use super::{Action, RestClient};
+    use crate::error::Result;
+
+    pub struct ActionsV2 {
+        client: RestClient,
+    }
+
+    impl ActionsV2 {
+        pub(crate) fn new(client: RestClient) -> Self {
+            Self { client }
+        }
+
+        pub async fn list(&self) -> Result<Vec<Action>> {
+            self.client.get("/v2/actions").await
+        }
+
+        pub async fn get(&self, action_uid: &str) -> Result<Action> {
+            self.client
+                .get(&format!("/v2/actions/{}", action_uid))
+                .await
+        }
+    }
 }

--- a/crates/redis-enterprise/src/actions.rs
+++ b/crates/redis-enterprise/src/actions.rs
@@ -50,20 +50,20 @@ impl ActionHandler {
             .await
     }
 
-    /// List actions via v2 API - GET /v2/actions (raw)
-    pub async fn list_v2_raw(&self) -> Result<Value> {
+    /// List actions via v2 API - GET /v2/actions
+    pub async fn list_v2(&self) -> Result<Vec<Action>> {
         self.client.get("/v2/actions").await
     }
 
-    /// Get action via v2 API - GET /v2/actions/{uid} (raw)
-    pub async fn get_v2_raw(&self, action_uid: &str) -> Result<Value> {
+    /// Get action via v2 API - GET /v2/actions/{uid}
+    pub async fn get_v2(&self, action_uid: &str) -> Result<Action> {
         self.client
             .get(&format!("/v2/actions/{}", action_uid))
             .await
     }
 
-    /// List actions for a database - GET /v1/actions/bdb/{uid} (raw)
-    pub async fn list_for_bdb_raw(&self, bdb_uid: u32) -> Result<Value> {
+    /// List actions for a database - GET /v1/actions/bdb/{uid}
+    pub async fn list_for_bdb(&self, bdb_uid: u32) -> Result<Vec<Action>> {
         self.client
             .get(&format!("/v1/actions/bdb/{}", bdb_uid))
             .await

--- a/crates/redis-enterprise/src/bdb.rs
+++ b/crates/redis-enterprise/src/bdb.rs
@@ -584,6 +584,356 @@ impl DatabaseHandler {
             .await
     }
 
+    /// Optimize shards placement (status) - GET
+    pub async fn optimize_shards_placement(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/v1/bdbs/{}/actions/optimize_shards_placement",
+                uid
+            ))
+            .await
+    }
+
+    /// Recover database (status) - GET
+    pub async fn recover_status(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/actions/recover", uid))
+            .await
+    }
+
+    /// Recover database - POST (typed)
+    pub async fn recover(&self, uid: u32) -> Result<DatabaseActionResponse> {
+        self.client
+            .post(
+                &format!("/v1/bdbs/{}/actions/recover", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Recover database - POST (raw)
+    pub async fn recover_raw(&self, uid: u32) -> Result<Value> {
+        self.client
+            .post(
+                &format!("/v1/bdbs/{}/actions/recover", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Resume traffic - POST (typed)
+    pub async fn resume_traffic(&self, uid: u32) -> Result<DatabaseActionResponse> {
+        self.client
+            .post(
+                &format!("/v1/bdbs/{}/actions/resume_traffic", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Resume traffic - POST (raw)
+    pub async fn resume_traffic_raw(&self, uid: u32) -> Result<Value> {
+        self.client
+            .post(
+                &format!("/v1/bdbs/{}/actions/resume_traffic", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Stop traffic - POST (typed)
+    pub async fn stop_traffic(&self, uid: u32) -> Result<DatabaseActionResponse> {
+        self.client
+            .post(
+                &format!("/v1/bdbs/{}/actions/stop_traffic", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Stop traffic - POST (raw)
+    pub async fn stop_traffic_raw(&self, uid: u32) -> Result<Value> {
+        self.client
+            .post(
+                &format!("/v1/bdbs/{}/actions/stop_traffic", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Rebalance database - PUT (typed)
+    pub async fn rebalance(&self, uid: u32) -> Result<DatabaseActionResponse> {
+        self.client
+            .put(
+                &format!("/v1/bdbs/{}/actions/rebalance", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Rebalance database - PUT (raw)
+    pub async fn rebalance_raw(&self, uid: u32) -> Result<Value> {
+        self.client
+            .put(
+                &format!("/v1/bdbs/{}/actions/rebalance", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Revamp database - PUT (typed)
+    pub async fn revamp(&self, uid: u32) -> Result<DatabaseActionResponse> {
+        self.client
+            .put(
+                &format!("/v1/bdbs/{}/actions/revamp", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Revamp database - PUT (raw)
+    pub async fn revamp_raw(&self, uid: u32) -> Result<Value> {
+        self.client
+            .put(
+                &format!("/v1/bdbs/{}/actions/revamp", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Reset backup status - PUT
+    pub async fn backup_reset_status(&self, uid: u32) -> Result<Value> {
+        self.client
+            .put(
+                &format!("/v1/bdbs/{}/actions/backup_reset_status", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Reset export status - PUT
+    pub async fn export_reset_status(&self, uid: u32) -> Result<Value> {
+        self.client
+            .put(
+                &format!("/v1/bdbs/{}/actions/export_reset_status", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Reset import status - PUT
+    pub async fn import_reset_status(&self, uid: u32) -> Result<Value> {
+        self.client
+            .put(
+                &format!("/v1/bdbs/{}/actions/import_reset_status", uid),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Peer stats for a database - GET
+    pub async fn peer_stats(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/peer_stats", uid))
+            .await
+    }
+
+    /// Peer stats for a specific peer - GET
+    pub async fn peer_stats_for(&self, uid: u32, peer_uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/peer_stats/{}", uid, peer_uid))
+            .await
+    }
+
+    /// Sync source stats for a database - GET
+    pub async fn sync_source_stats(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/sync_source_stats", uid))
+            .await
+    }
+
+    /// Sync source stats for a specific source - GET
+    pub async fn sync_source_stats_for(&self, uid: u32, src_uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/sync_source_stats/{}", uid, src_uid))
+            .await
+    }
+
+    /// Syncer state (all) - GET
+    pub async fn syncer_state(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/syncer_state", uid))
+            .await
+    }
+
+    /// Syncer state for CRDT - GET
+    pub async fn syncer_state_crdt(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/syncer_state/crdt", uid))
+            .await
+    }
+
+    /// Syncer state for replica - GET
+    pub async fn syncer_state_replica(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/{}/syncer_state/replica", uid))
+            .await
+    }
+
+    /// Generic database command passthrough - POST
+    pub async fn command_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bdbs/{}/command", uid), &body)
+            .await
+    }
+
+    /// Database passwords create - POST (raw)
+    pub async fn passwords_create_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bdbs/{}/passwords", uid), &body)
+            .await
+    }
+
+    /// Database passwords update - PUT (raw)
+    pub async fn passwords_update_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .put(&format!("/v1/bdbs/{}/passwords", uid), &body)
+            .await
+    }
+
+    /// Database passwords delete - DELETE
+    pub async fn passwords_delete(&self, uid: u32) -> Result<()> {
+        self.client
+            .delete(&format!("/v1/bdbs/{}/passwords", uid))
+            .await
+    }
+
+    /// Post database alert operation - POST (raw)
+    pub async fn alerts_post_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bdbs/alerts/{}", uid), &body)
+            .await
+    }
+
+    /// List all database alerts - GET
+    pub async fn alerts_all(&self) -> Result<Value> {
+        self.client.get("/v1/bdbs/alerts").await
+    }
+
+    /// List alerts for a specific database - GET
+    pub async fn alerts_for(&self, uid: u32) -> Result<Value> {
+        self.client.get(&format!("/v1/bdbs/alerts/{}", uid)).await
+    }
+
+    /// Get a specific alert for a database - GET
+    pub async fn alert_detail(&self, uid: u32, alert: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/alerts/{}/{}", uid, alert))
+            .await
+    }
+
+    /// CRDT source alerts - GET
+    pub async fn crdt_source_alerts_all(&self) -> Result<Value> {
+        self.client.get("/v1/bdbs/crdt_sources/alerts").await
+    }
+
+    /// CRDT source alerts for DB - GET
+    pub async fn crdt_source_alerts_for(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/crdt_sources/alerts/{}", uid))
+            .await
+    }
+
+    /// CRDT source alerts for specific source - GET
+    pub async fn crdt_source_alerts_source(&self, uid: u32, source_id: u32) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/v1/bdbs/crdt_sources/alerts/{}/{}",
+                uid, source_id
+            ))
+            .await
+    }
+
+    /// CRDT source alert detail - GET
+    pub async fn crdt_source_alert_detail(
+        &self,
+        uid: u32,
+        source_id: u32,
+        alert: &str,
+    ) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/v1/bdbs/crdt_sources/alerts/{}/{}/{}",
+                uid, source_id, alert
+            ))
+            .await
+    }
+
+    /// Replica source alerts - GET
+    pub async fn replica_source_alerts_all(&self) -> Result<Value> {
+        self.client.get("/v1/bdbs/replica_sources/alerts").await
+    }
+
+    /// Replica source alerts for DB - GET
+    pub async fn replica_source_alerts_for(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/bdbs/replica_sources/alerts/{}", uid))
+            .await
+    }
+
+    /// Replica source alerts for specific source - GET
+    pub async fn replica_source_alerts_source(&self, uid: u32, source_id: u32) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/v1/bdbs/replica_sources/alerts/{}/{}",
+                uid, source_id
+            ))
+            .await
+    }
+
+    /// Replica source alert detail - GET
+    pub async fn replica_source_alert_detail(
+        &self,
+        uid: u32,
+        source_id: u32,
+        alert: &str,
+    ) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/v1/bdbs/replica_sources/alerts/{}/{}/{}",
+                uid, source_id, alert
+            ))
+            .await
+    }
+
+    /// Modules config for a database - POST (raw)
+    pub async fn modules_config_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bdbs/{}/modules/config", uid), &body)
+            .await
+    }
+
+    /// Modules upgrade for a database - POST (raw)
+    pub async fn modules_upgrade_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bdbs/{}/modules/upgrade", uid), &body)
+            .await
+    }
+
+    /// Engine upgrade shortcut (non-actions) - POST (raw)
+    pub async fn upgrade_direct_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bdbs/{}/upgrade", uid), &body)
+            .await
+    }
+
+    /// Update a single field via path - PUT (raw)
+    pub async fn update_field_raw(&self, uid: u32, field: &str, body: Value) -> Result<Value> {
+        self.client
+            .put(&format!("/v1/bdbs/{}/{}", uid, field), &body)
+            .await
+    }
+
     /// Upgrade database with new module version (BDB.UPGRADE) - typed version
     pub async fn upgrade(
         &self,

--- a/crates/redis-enterprise/src/bdb.rs
+++ b/crates/redis-enterprise/src/bdb.rs
@@ -1,4 +1,12 @@
 //! Database (BDB) management commands for Redis Enterprise
+//!
+//! Overview
+//! - Create, update, delete databases
+//! - Operational actions: start/stop/restart, export/import/backup/restore
+//! - Insights: endpoints, shards, metrics/stats, availability
+//! - Advanced: passwords, modules config/upgrade, traffic control
+//!
+//! Tip: For time-series metrics, also see the `StatsHandler` for aggregate queries.
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/bdb.rs
+++ b/crates/redis-enterprise/src/bdb.rs
@@ -26,7 +26,8 @@ pub struct DatabaseActionResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackupResponse {
     /// The action UID for tracking the backup operation
-    pub action_uid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_uid: Option<String>,
     /// Backup UID if available
     pub backup_uid: Option<String>,
     /// Additional fields from the response
@@ -38,7 +39,8 @@ pub struct BackupResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportResponse {
     /// The action UID for tracking the import operation
-    pub action_uid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_uid: Option<String>,
     /// Import status
     pub status: Option<String>,
     /// Additional fields from the response
@@ -50,7 +52,8 @@ pub struct ImportResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportResponse {
     /// The action UID for tracking the export operation
-    pub action_uid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_uid: Option<String>,
     /// Export status
     pub status: Option<String>,
     /// Additional fields from the response

--- a/crates/redis-enterprise/src/bdb_groups.rs
+++ b/crates/redis-enterprise/src/bdb_groups.rs
@@ -1,0 +1,46 @@
+//! Database Groups management for Redis Enterprise
+
+use crate::client::RestClient;
+use crate::error::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BdbGroup {
+    pub uid: u32,
+    pub name: String,
+    #[serde(flatten)]
+    pub extra: Value,
+}
+
+pub struct BdbGroupsHandler {
+    client: RestClient,
+}
+
+impl BdbGroupsHandler {
+    pub fn new(client: RestClient) -> Self {
+        BdbGroupsHandler { client }
+    }
+
+    pub async fn list(&self) -> Result<Vec<BdbGroup>> {
+        self.client.get("/v1/bdb_groups").await
+    }
+
+    pub async fn get(&self, uid: u32) -> Result<BdbGroup> {
+        self.client.get(&format!("/v1/bdb_groups/{}", uid)).await
+    }
+
+    pub async fn create_raw(&self, body: Value) -> Result<BdbGroup> {
+        self.client.post("/v1/bdb_groups", &body).await
+    }
+
+    pub async fn update_raw(&self, uid: u32, body: Value) -> Result<BdbGroup> {
+        self.client
+            .put(&format!("/v1/bdb_groups/{}", uid), &body)
+            .await
+    }
+
+    pub async fn delete(&self, uid: u32) -> Result<()> {
+        self.client.delete(&format!("/v1/bdb_groups/{}", uid)).await
+    }
+}

--- a/crates/redis-enterprise/src/bdb_groups.rs
+++ b/crates/redis-enterprise/src/bdb_groups.rs
@@ -30,11 +30,11 @@ impl BdbGroupsHandler {
         self.client.get(&format!("/v1/bdb_groups/{}", uid)).await
     }
 
-    pub async fn create_raw(&self, body: Value) -> Result<BdbGroup> {
+    pub async fn create(&self, body: CreateBdbGroupRequest) -> Result<BdbGroup> {
         self.client.post("/v1/bdb_groups", &body).await
     }
 
-    pub async fn update_raw(&self, uid: u32, body: Value) -> Result<BdbGroup> {
+    pub async fn update(&self, uid: u32, body: UpdateBdbGroupRequest) -> Result<BdbGroup> {
         self.client
             .put(&format!("/v1/bdb_groups/{}", uid), &body)
             .await
@@ -43,4 +43,15 @@ impl BdbGroupsHandler {
     pub async fn delete(&self, uid: u32) -> Result<()> {
         self.client.delete(&format!("/v1/bdb_groups/{}", uid)).await
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateBdbGroupRequest {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateBdbGroupRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }

--- a/crates/redis-enterprise/src/bootstrap.rs
+++ b/crates/redis-enterprise/src/bootstrap.rs
@@ -95,4 +95,18 @@ impl BootstrapHandler {
     pub async fn reset(&self) -> Result<()> {
         self.client.delete("/v1/bootstrap").await
     }
+
+    /// Validate bootstrap for a specific UID - POST /v1/bootstrap/validate/{uid}
+    pub async fn validate_for(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bootstrap/validate/{}", uid), &body)
+            .await
+    }
+
+    /// Post a specific bootstrap action - POST /v1/bootstrap/{action}
+    pub async fn post_action(&self, action: &str, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/bootstrap/{}", action), &body)
+            .await
+    }
 }

--- a/crates/redis-enterprise/src/cluster.rs
+++ b/crates/redis-enterprise/src/cluster.rs
@@ -1,4 +1,10 @@
 //! Cluster management commands for Redis Enterprise
+//!
+//! Overview
+//! - Read: info, settings, topology, license, nodes
+//! - Actions: reset, recover, join node, policy and services configuration
+//! - Certificates and LDAP helpers
+//! - Alert detail queries
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/cluster.rs
+++ b/crates/redis-enterprise/src/cluster.rs
@@ -235,12 +235,7 @@ impl ClusterHandler {
             .await
     }
 
-    /// Reset cluster to factory defaults (CLUSTER.RESET) - DANGEROUS - raw version
-    pub async fn reset_raw(&self) -> Result<Value> {
-        self.client
-            .post("/v1/cluster/actions/reset", &serde_json::json!({}))
-            .await
-    }
+    // raw variant removed: use reset()
 
     /// Recover cluster from failure (CLUSTER.RECOVER) - typed version
     pub async fn recover(&self) -> Result<ClusterActionResponse> {
@@ -249,12 +244,7 @@ impl ClusterHandler {
             .await
     }
 
-    /// Recover cluster from failure (CLUSTER.RECOVER) - raw version
-    pub async fn recover_raw(&self) -> Result<Value> {
-        self.client
-            .post("/v1/cluster/actions/recover", &serde_json::json!({}))
-            .await
-    }
+    // raw variant removed: use recover()
 
     /// Get cluster settings (CLUSTER.SETTINGS)
     pub async fn settings(&self) -> Result<Value> {

--- a/crates/redis-enterprise/src/cluster.rs
+++ b/crates/redis-enterprise/src/cluster.rs
@@ -265,6 +265,122 @@ impl ClusterHandler {
     pub async fn topology(&self) -> Result<Value> {
         self.client.get("/v1/cluster/topology").await
     }
+
+    /// List available cluster actions - GET /v1/cluster/actions
+    pub async fn actions(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/actions").await
+    }
+
+    /// Get a specific cluster action details - GET /v1/cluster/actions/{action}
+    pub async fn action_detail(&self, action: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/cluster/actions/{}", action))
+            .await
+    }
+
+    /// Execute a specific cluster action - POST /v1/cluster/actions/{action}
+    pub async fn action_execute(&self, action: &str, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/cluster/actions/{}", action), &body)
+            .await
+    }
+
+    /// Delete a specific cluster action - DELETE /v1/cluster/actions/{action}
+    pub async fn action_delete(&self, action: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/v1/cluster/actions/{}", action))
+            .await
+    }
+
+    /// Get auditing DB connections - GET /v1/cluster/auditing/db_conns
+    pub async fn auditing_db_conns(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/auditing/db_conns").await
+    }
+
+    /// Update auditing DB connections - PUT /v1/cluster/auditing/db_conns
+    pub async fn auditing_db_conns_update(&self, cfg: Value) -> Result<Value> {
+        self.client.put("/v1/cluster/auditing/db_conns", &cfg).await
+    }
+
+    /// Delete auditing DB connections - DELETE /v1/cluster/auditing/db_conns
+    pub async fn auditing_db_conns_delete(&self) -> Result<()> {
+        self.client.delete("/v1/cluster/auditing/db_conns").await
+    }
+
+    /// List cluster certificates - GET /v1/cluster/certificates
+    pub async fn certificates(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/certificates").await
+    }
+
+    /// Delete a certificate - DELETE /v1/cluster/certificates/{uid}
+    pub async fn certificate_delete(&self, uid: u32) -> Result<()> {
+        self.client
+            .delete(&format!("/v1/cluster/certificates/{}", uid))
+            .await
+    }
+
+    /// Rotate certificates - POST /v1/cluster/certificates/rotate
+    pub async fn certificates_rotate(&self) -> Result<Value> {
+        self.client
+            .post("/v1/cluster/certificates/rotate", &serde_json::json!({}))
+            .await
+    }
+
+    /// Update certificate bundle - PUT /v1/cluster/update_cert
+    pub async fn update_cert(&self, body: Value) -> Result<Value> {
+        self.client.put("/v1/cluster/update_cert", &body).await
+    }
+
+    /// Delete LDAP configuration - DELETE /v1/cluster/ldap
+    pub async fn ldap_delete(&self) -> Result<()> {
+        self.client.delete("/v1/cluster/ldap").await
+    }
+
+    /// Get cluster module capabilities - GET /v1/cluster/module-capabilities
+    pub async fn module_capabilities(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/module-capabilities").await
+    }
+
+    /// Get cluster policy - GET /v1/cluster/policy
+    pub async fn policy(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/policy").await
+    }
+
+    /// Update cluster policy - PUT /v1/cluster/policy
+    pub async fn policy_update(&self, policy: Value) -> Result<Value> {
+        self.client.put("/v1/cluster/policy", &policy).await
+    }
+
+    /// Restore default cluster policy - PUT /v1/cluster/policy/restore_default
+    pub async fn policy_restore_default(&self) -> Result<Value> {
+        self.client
+            .put("/v1/cluster/policy/restore_default", &serde_json::json!({}))
+            .await
+    }
+
+    /// Get services configuration - GET /v1/cluster/services_configuration
+    pub async fn services_configuration(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/services_configuration").await
+    }
+
+    /// Update services configuration - PUT /v1/cluster/services_configuration
+    pub async fn services_configuration_update(&self, cfg: Value) -> Result<Value> {
+        self.client
+            .put("/v1/cluster/services_configuration", &cfg)
+            .await
+    }
+
+    /// Get witness disk info - GET /v1/cluster/witness_disk
+    pub async fn witness_disk(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/witness_disk").await
+    }
+
+    /// Get specific cluster alert detail - GET /v1/cluster/alerts/{alert}
+    pub async fn alert_detail(&self, alert: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/cluster/alerts/{}", alert))
+            .await
+    }
 }
 
 /// Node information

--- a/crates/redis-enterprise/src/debuginfo.rs
+++ b/crates/redis-enterprise/src/debuginfo.rs
@@ -90,4 +90,28 @@ impl DebugInfoHandler {
             .delete(&format!("/v1/debuginfo/{}", task_id))
             .await
     }
+
+    /// Get all debug info across nodes - GET /v1/debuginfo/all
+    pub async fn all(&self) -> Result<Value> {
+        self.client.get("/v1/debuginfo/all").await
+    }
+
+    /// Get all debug info for a specific database - GET /v1/debuginfo/all/bdb/{uid}
+    pub async fn all_bdb(&self, bdb_uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/debuginfo/all/bdb/{}", bdb_uid))
+            .await
+    }
+
+    /// Get node debug info - GET /v1/debuginfo/node
+    pub async fn node(&self) -> Result<Value> {
+        self.client.get("/v1/debuginfo/node").await
+    }
+
+    /// Get node debug info for a specific database - GET /v1/debuginfo/node/bdb/{uid}
+    pub async fn node_bdb(&self, bdb_uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/debuginfo/node/bdb/{}", bdb_uid))
+            .await
+    }
 }

--- a/crates/redis-enterprise/src/debuginfo.rs
+++ b/crates/redis-enterprise/src/debuginfo.rs
@@ -1,4 +1,8 @@
 //! Debug information collection for Redis Enterprise
+//!
+//! Overview
+//! - Create and track debuginfo tasks, download artifacts
+//! - Convenience routes for node/all scopes
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/diagnostics.rs
+++ b/crates/redis-enterprise/src/diagnostics.rs
@@ -1,4 +1,8 @@
 //! Diagnostic operations for Redis Enterprise
+//!
+//! Overview
+//! - Run checks, retrieve reports, and list available checks
+//! - Typed config GET/PUT for diagnostics settings
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/diagnostics.rs
+++ b/crates/redis-enterprise/src/diagnostics.rs
@@ -94,4 +94,14 @@ impl DiagnosticsHandler {
     pub async fn list_reports(&self) -> Result<Vec<DiagnosticReport>> {
         self.client.get("/v1/diagnostics/reports").await
     }
+
+    /// Get diagnostics configuration/state - GET /v1/diagnostics
+    pub async fn get_config(&self) -> Result<Value> {
+        self.client.get("/v1/diagnostics").await
+    }
+
+    /// Update diagnostics configuration/state - PUT /v1/diagnostics
+    pub async fn update_config(&self, body: Value) -> Result<Value> {
+        self.client.put("/v1/diagnostics", &body).await
+    }
 }

--- a/crates/redis-enterprise/src/job_scheduler.rs
+++ b/crates/redis-enterprise/src/job_scheduler.rs
@@ -120,4 +120,9 @@ impl JobSchedulerHandler {
             .get(&format!("/v1/job_scheduler/{}/history", job_id))
             .await
     }
+
+    /// Update job scheduler globally - PUT /v1/job_scheduler (raw)
+    pub async fn update_all_raw(&self, body: Value) -> Result<Value> {
+        self.client.put("/v1/job_scheduler", &body).await
+    }
 }

--- a/crates/redis-enterprise/src/job_scheduler.rs
+++ b/crates/redis-enterprise/src/job_scheduler.rs
@@ -121,8 +121,8 @@ impl JobSchedulerHandler {
             .await
     }
 
-    /// Update job scheduler globally - PUT /v1/job_scheduler (raw)
-    pub async fn update_all_raw(&self, body: Value) -> Result<Value> {
+    /// Update job scheduler globally - PUT /v1/job_scheduler
+    pub async fn update_all(&self, body: Value) -> Result<Vec<ScheduledJob>> {
         self.client.put("/v1/job_scheduler", &body).await
     }
 }

--- a/crates/redis-enterprise/src/lib.rs
+++ b/crates/redis-enterprise/src/lib.rs
@@ -7,12 +7,14 @@
 //!
 //! # Features
 //!
-//! - **Complete API Coverage**: All 29 Enterprise REST API endpoint categories
+//! - **Complete API Coverage**: Full coverage of v1 endpoints plus select v2
+//!   endpoints where they exist (e.g., actions, modules)
 //! - **Type-Safe Operations**: Strongly typed request/response models
 //! - **Flexible Authentication**: Basic auth with optional SSL verification
 //! - **Async/Await Support**: Built on Tokio for high-performance async operations
 //! - **Error Handling**: Comprehensive error types with context
 //! - **Builder Patterns**: Ergonomic API for complex request construction
+//! - **Versioned APIs**: Clear accessors for v1 and v2 where both exist
 //!
 //! # Quick Start
 //!
@@ -133,6 +135,36 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## Versioned Endpoints (v1/v2)
+//!
+//! Some Enterprise endpoints have both v1 and v2 flavors. Use versioned sub-handlers
+//! to make intent explicit and keep models clean.
+//!
+//! ```no_run
+//! use redis_enterprise::{EnterpriseClient, ActionHandler, ModuleHandler};
+//!
+//! # async fn example(client: EnterpriseClient) -> Result<(), Box<dyn std::error::Error>> {
+//! // Actions: v1 and v2
+//! let actions = ActionHandler::new(client.clone());
+//! let v1_actions = actions.v1().list().await?; // GET /v1/actions
+//! let v2_actions = actions.v2().list().await?; // GET /v2/actions
+//!
+//! // Modules: v1 and v2
+//! let modules = ModuleHandler::new(client.clone());
+//! let all = modules.v1().list().await?;            // GET /v1/modules
+//! // v2 upload body can be an opaque Value or multipart in a higher-level helper
+//! let uploaded = modules.v2().upload(serde_json::json!({"name": "search", "data": "..."})).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Typed-Only Client
+//!
+//! The Enterprise client exposes typed request/response APIs by default. Raw JSON
+//! passthroughs are avoided except for intentionally opaque operations (for example,
+//! database command passthrough or module uploads). This keeps CLI and library usage
+//! consistent and safer while maintaining flexibility where the wire format is open.
 //!
 //! ## User Management
 //!

--- a/crates/redis-enterprise/src/lib.rs
+++ b/crates/redis-enterprise/src/lib.rs
@@ -262,6 +262,7 @@
 pub mod actions;
 pub mod alerts;
 pub mod bdb;
+pub mod bdb_groups;
 pub mod bootstrap;
 pub mod client;
 pub mod cluster;
@@ -276,6 +277,7 @@ pub mod job_scheduler;
 pub mod jsonschema;
 pub mod ldap_mappings;
 pub mod license;
+pub mod local;
 pub mod logs;
 pub mod migrations;
 pub mod modules;
@@ -303,6 +305,9 @@ pub use error::{RestError, Result};
 pub use bdb::{
     BdbHandler, CreateDatabaseRequest, CreateDatabaseRequestBuilder, Database, ModuleConfig,
 };
+
+// Database groups
+pub use bdb_groups::{BdbGroup, BdbGroupsHandler};
 
 // Cluster management
 pub use cluster::{
@@ -349,6 +354,9 @@ pub use ldap_mappings::{
 
 // OCSP
 pub use ocsp::{OcspConfig, OcspHandler, OcspStatus, OcspTestResult};
+
+// Local endpoints
+pub use local::LocalHandler;
 
 // Bootstrap
 pub use bootstrap::{

--- a/crates/redis-enterprise/src/local.rs
+++ b/crates/redis-enterprise/src/local.rs
@@ -1,0 +1,30 @@
+//! Local node and services endpoints
+
+use crate::client::RestClient;
+use crate::error::Result;
+use serde_json::Value;
+
+pub struct LocalHandler {
+    client: RestClient,
+}
+
+impl LocalHandler {
+    pub fn new(client: RestClient) -> Self {
+        LocalHandler { client }
+    }
+
+    /// Master healthcheck for local node - GET /v1/local/node/master_healthcheck
+    pub async fn master_healthcheck(&self) -> Result<Value> {
+        self.client.get("/v1/local/node/master_healthcheck").await
+    }
+
+    /// List local services - GET /v1/local/services
+    pub async fn services(&self) -> Result<Value> {
+        self.client.get("/v1/local/services").await
+    }
+
+    /// Create/update local services - POST /v1/local/services
+    pub async fn services_update(&self, body: Value) -> Result<Value> {
+        self.client.post("/v1/local/services", &body).await
+    }
+}

--- a/crates/redis-enterprise/src/modules.rs
+++ b/crates/redis-enterprise/src/modules.rs
@@ -99,4 +99,76 @@ impl ModuleHandler {
     pub async fn delete_v2(&self, uid: &str) -> Result<()> {
         self.client.delete(&format!("/v2/modules/{}", uid)).await
     }
+
+    // Versioned accessors
+    pub fn v1(&self) -> v1::ModulesV1 {
+        v1::ModulesV1::new(self.client.clone())
+    }
+
+    pub fn v2(&self) -> v2::ModulesV2 {
+        v2::ModulesV2::new(self.client.clone())
+    }
+}
+
+pub mod v1 {
+    use super::{Module, RestClient};
+    use crate::error::Result;
+    use serde_json::Value;
+
+    pub struct ModulesV1 {
+        client: RestClient,
+    }
+
+    impl ModulesV1 {
+        pub(crate) fn new(client: RestClient) -> Self {
+            Self { client }
+        }
+
+        pub async fn list(&self) -> Result<Vec<Module>> {
+            self.client.get("/v1/modules").await
+        }
+
+        pub async fn get(&self, uid: &str) -> Result<Module> {
+            self.client.get(&format!("/v1/modules/{}", uid)).await
+        }
+
+        pub async fn upload(&self, data: Vec<u8>) -> Result<Module> {
+            let body = serde_json::json!({ "module": data });
+            self.client.post("/v1/modules", &body).await
+        }
+
+        pub async fn delete(&self, uid: &str) -> Result<()> {
+            self.client.delete(&format!("/v1/modules/{}", uid)).await
+        }
+
+        pub async fn update(&self, uid: &str, updates: Value) -> Result<Module> {
+            self.client
+                .put(&format!("/v1/modules/{}", uid), &updates)
+                .await
+        }
+    }
+}
+
+pub mod v2 {
+    use super::{Module, RestClient};
+    use crate::error::Result;
+    use serde_json::Value;
+
+    pub struct ModulesV2 {
+        client: RestClient,
+    }
+
+    impl ModulesV2 {
+        pub(crate) fn new(client: RestClient) -> Self {
+            Self { client }
+        }
+
+        pub async fn upload(&self, body: Value) -> Result<Module> {
+            self.client.post("/v2/modules", &body).await
+        }
+
+        pub async fn delete(&self, uid: &str) -> Result<()> {
+            self.client.delete(&format!("/v2/modules/{}", uid)).await
+        }
+    }
 }

--- a/crates/redis-enterprise/src/modules.rs
+++ b/crates/redis-enterprise/src/modules.rs
@@ -75,4 +75,28 @@ impl ModuleHandler {
             .put(&format!("/v1/modules/{}", uid), &updates)
             .await
     }
+
+    /// Configure modules for a specific database - POST /v1/modules/config/bdb/{uid} (raw)
+    pub async fn config_bdb_raw(&self, bdb_uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/modules/config/bdb/{}", bdb_uid), &body)
+            .await
+    }
+
+    /// Upgrade modules for a specific database - POST /v1/modules/upgrade/bdb/{uid} (raw)
+    pub async fn upgrade_bdb_raw(&self, bdb_uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/modules/upgrade/bdb/{}", bdb_uid), &body)
+            .await
+    }
+
+    /// Upload module via v2 API - POST /v2/modules (raw)
+    pub async fn upload_v2_raw(&self, body: Value) -> Result<Value> {
+        self.client.post("/v2/modules", &body).await
+    }
+
+    /// Delete module via v2 API - DELETE /v2/modules/{uid}
+    pub async fn delete_v2(&self, uid: &str) -> Result<()> {
+        self.client.delete(&format!("/v2/modules/{}", uid)).await
+    }
 }

--- a/crates/redis-enterprise/src/modules.rs
+++ b/crates/redis-enterprise/src/modules.rs
@@ -76,22 +76,22 @@ impl ModuleHandler {
             .await
     }
 
-    /// Configure modules for a specific database - POST /v1/modules/config/bdb/{uid} (raw)
-    pub async fn config_bdb_raw(&self, bdb_uid: u32, body: Value) -> Result<Value> {
+    /// Configure modules for a specific database - POST /v1/modules/config/bdb/{uid}
+    pub async fn config_bdb(&self, bdb_uid: u32, config: Value) -> Result<Module> {
         self.client
-            .post(&format!("/v1/modules/config/bdb/{}", bdb_uid), &body)
+            .post(&format!("/v1/modules/config/bdb/{}", bdb_uid), &config)
             .await
     }
 
-    /// Upgrade modules for a specific database - POST /v1/modules/upgrade/bdb/{uid} (raw)
-    pub async fn upgrade_bdb_raw(&self, bdb_uid: u32, body: Value) -> Result<Value> {
+    /// Upgrade modules for a specific database - POST /v1/modules/upgrade/bdb/{uid}
+    pub async fn upgrade_bdb(&self, bdb_uid: u32, body: Value) -> Result<Module> {
         self.client
             .post(&format!("/v1/modules/upgrade/bdb/{}", bdb_uid), &body)
             .await
     }
 
-    /// Upload module via v2 API - POST /v2/modules (raw)
-    pub async fn upload_v2_raw(&self, body: Value) -> Result<Value> {
+    /// Upload module via v2 API - POST /v2/modules
+    pub async fn upload_v2(&self, body: Value) -> Result<Module> {
         self.client.post("/v2/modules", &body).await
     }
 

--- a/crates/redis-enterprise/src/modules.rs
+++ b/crates/redis-enterprise/src/modules.rs
@@ -1,4 +1,9 @@
 //! Redis module management for Redis Enterprise
+//!
+//! Overview
+//! - v1: list/get/upload/update/delete
+//! - v2: modern upload/delete APIs
+//!   Accessors `v1()` and `v2()` provide explicit version selection.
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/nodes.rs
+++ b/crates/redis-enterprise/src/nodes.rs
@@ -1,4 +1,10 @@
 //! Node management for Redis Enterprise
+//!
+//! Overview
+//! - List/get/update/remove nodes
+//! - Node actions (e.g., maintenance_on/off) with typed responses
+//! - Status and watchdog status (per-node and aggregate)
+//! - Shards and proxies per-node
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/nodes.rs
+++ b/crates/redis-enterprise/src/nodes.rs
@@ -176,16 +176,7 @@ impl NodeHandler {
             .await
     }
 
-    /// Execute node action (e.g., "maintenance_on", "maintenance_off") - raw version
-    pub async fn execute_action_raw(&self, uid: u32, action: &str) -> Result<Value> {
-        let request = NodeActionRequest {
-            action: action.to_string(),
-            node_uid: Some(uid),
-        };
-        self.client
-            .post(&format!("/v1/nodes/{}/actions", uid), &request)
-            .await
-    }
+    // raw variant removed in favor of typed execute_action
 
     /// List all available node actions (global) - GET /v1/nodes/actions
     pub async fn list_actions(&self) -> Result<Value> {

--- a/crates/redis-enterprise/src/nodes.rs
+++ b/crates/redis-enterprise/src/nodes.rs
@@ -186,4 +186,93 @@ impl NodeHandler {
             .post(&format!("/v1/nodes/{}/actions", uid), &request)
             .await
     }
+
+    /// List all available node actions (global) - GET /v1/nodes/actions
+    pub async fn list_actions(&self) -> Result<Value> {
+        self.client.get("/v1/nodes/actions").await
+    }
+
+    /// Get node action detail - GET /v1/nodes/{uid}/actions/{action}
+    pub async fn action_detail(&self, uid: u32, action: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/nodes/{}/actions/{}", uid, action))
+            .await
+    }
+
+    /// Execute named node action - POST /v1/nodes/{uid}/actions/{action}
+    pub async fn action_execute(&self, uid: u32, action: &str, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/nodes/{}/actions/{}", uid, action), &body)
+            .await
+    }
+
+    /// Delete node action - DELETE /v1/nodes/{uid}/actions/{action}
+    pub async fn action_delete(&self, uid: u32, action: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/v1/nodes/{}/actions/{}", uid, action))
+            .await
+    }
+
+    /// List snapshots for a node - GET /v1/nodes/{uid}/snapshots
+    pub async fn snapshots(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/nodes/{}/snapshots", uid))
+            .await
+    }
+
+    /// Create a snapshot - POST /v1/nodes/{uid}/snapshots/{name}
+    pub async fn snapshot_create(&self, uid: u32, name: &str) -> Result<Value> {
+        self.client
+            .post(
+                &format!("/v1/nodes/{}/snapshots/{}", uid, name),
+                &serde_json::json!({}),
+            )
+            .await
+    }
+
+    /// Delete a snapshot - DELETE /v1/nodes/{uid}/snapshots/{name}
+    pub async fn snapshot_delete(&self, uid: u32, name: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/v1/nodes/{}/snapshots/{}", uid, name))
+            .await
+    }
+
+    /// All nodes status - GET /v1/nodes/status
+    pub async fn status_all(&self) -> Result<Value> {
+        self.client.get("/v1/nodes/status").await
+    }
+
+    /// Watchdog status for all nodes - GET /v1/nodes/wd_status
+    pub async fn wd_status_all(&self) -> Result<Value> {
+        self.client.get("/v1/nodes/wd_status").await
+    }
+
+    /// Node status - GET /v1/nodes/{uid}/status
+    pub async fn status(&self, uid: u32) -> Result<Value> {
+        self.client.get(&format!("/v1/nodes/{}/status", uid)).await
+    }
+
+    /// Node watchdog status - GET /v1/nodes/{uid}/wd_status
+    pub async fn wd_status(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/nodes/{}/wd_status", uid))
+            .await
+    }
+
+    /// All node alerts - GET /v1/nodes/alerts
+    pub async fn alerts_all(&self) -> Result<Value> {
+        self.client.get("/v1/nodes/alerts").await
+    }
+
+    /// Alerts for node - GET /v1/nodes/alerts/{uid}
+    pub async fn alerts_for(&self, uid: u32) -> Result<Value> {
+        self.client.get(&format!("/v1/nodes/alerts/{}", uid)).await
+    }
+
+    /// Alert detail - GET /v1/nodes/alerts/{uid}/{alert}
+    pub async fn alert_detail(&self, uid: u32, alert: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/nodes/alerts/{}/{}", uid, alert))
+            .await
+    }
 }

--- a/crates/redis-enterprise/src/ocsp.rs
+++ b/crates/redis-enterprise/src/ocsp.rs
@@ -1,4 +1,8 @@
 //! OCSP (Online Certificate Status Protocol) management for Redis Enterprise
+//!
+//! Overview
+//! - Query and configure OCSP settings
+//! - Status check and test endpoints
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/ocsp.rs
+++ b/crates/redis-enterprise/src/ocsp.rs
@@ -86,6 +86,13 @@ impl OcspHandler {
         self.client.get("/v1/ocsp/test").await
     }
 
+    /// Test OCSP via POST
+    pub async fn test_post(&self) -> Result<OcspTestResult> {
+        self.client
+            .post("/v1/ocsp/test", &serde_json::Value::Null)
+            .await
+    }
+
     /// Trigger OCSP query
     pub async fn query(&self) -> Result<()> {
         self.client

--- a/crates/redis-enterprise/src/proxies.rs
+++ b/crates/redis-enterprise/src/proxies.rs
@@ -8,12 +8,9 @@ use serde_json::Value;
 /// Response for a single metric query
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricResponse {
-    /// Metric name
-    pub metric: String,
-    /// Metric value
-    pub value: Value,
-    /// Timestamp if available
-    pub timestamp: Option<String>,
+    pub interval: String,
+    pub timestamps: Vec<i64>,
+    pub values: Vec<Value>,
     #[serde(flatten)]
     pub extra: Value,
 }
@@ -116,14 +113,25 @@ impl ProxyHandler {
     }
 
     /// Update proxies (bulk) - PUT /v1/proxies
-    pub async fn update_all_raw(&self, body: Value) -> Result<Value> {
-        self.client.put("/v1/proxies", &body).await
+    pub async fn update_all(&self, update: ProxyUpdate) -> Result<Vec<Proxy>> {
+        self.client.put("/v1/proxies", &update).await
     }
 
     /// Update specific proxy - PUT /v1/proxies/{uid}
-    pub async fn update_raw(&self, uid: u32, body: Value) -> Result<Value> {
+    pub async fn update(&self, uid: u32, update: ProxyUpdate) -> Result<Proxy> {
         self.client
-            .put(&format!("/v1/proxies/{}", uid), &body)
+            .put(&format!("/v1/proxies/{}", uid), &update)
             .await
     }
+}
+
+/// Proxy update body
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProxyUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_connections: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threads: Option<u32>,
+    #[serde(flatten)]
+    pub extra: Value,
 }

--- a/crates/redis-enterprise/src/proxies.rs
+++ b/crates/redis-enterprise/src/proxies.rs
@@ -1,4 +1,9 @@
 //! Proxy management for Redis Enterprise
+//!
+//! Overview
+//! - List/get proxies
+//! - Per-proxy metrics (interval/timestamps/values)
+//! - Bulk and per-proxy updates via typed `ProxyUpdate`
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/proxies.rs
+++ b/crates/redis-enterprise/src/proxies.rs
@@ -114,4 +114,16 @@ impl ProxyHandler {
             .post_action(&format!("/v1/proxies/{}/actions/reload", uid), &Value::Null)
             .await
     }
+
+    /// Update proxies (bulk) - PUT /v1/proxies
+    pub async fn update_all_raw(&self, body: Value) -> Result<Value> {
+        self.client.put("/v1/proxies", &body).await
+    }
+
+    /// Update specific proxy - PUT /v1/proxies/{uid}
+    pub async fn update_raw(&self, uid: u32, body: Value) -> Result<Value> {
+        self.client
+            .put(&format!("/v1/proxies/{}", uid), &body)
+            .await
+    }
 }

--- a/crates/redis-enterprise/src/redis_acls.rs
+++ b/crates/redis-enterprise/src/redis_acls.rs
@@ -70,4 +70,9 @@ impl RedisAclHandler {
     pub async fn delete(&self, uid: u32) -> Result<()> {
         self.client.delete(&format!("/v1/redis_acls/{}", uid)).await
     }
+
+    /// Validate an ACL payload - POST /v1/redis_acls/validate (raw)
+    pub async fn validate_raw(&self, body: Value) -> Result<Value> {
+        self.client.post("/v1/redis_acls/validate", &body).await
+    }
 }

--- a/crates/redis-enterprise/src/redis_acls.rs
+++ b/crates/redis-enterprise/src/redis_acls.rs
@@ -1,4 +1,8 @@
 //! Redis Access Control List (ACL) management for Redis Enterprise
+//!
+//! Overview
+//! - Typed create/update/delete and list/get
+//! - Validate ACL definitions with a typed response
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/redis_acls.rs
+++ b/crates/redis-enterprise/src/redis_acls.rs
@@ -71,8 +71,17 @@ impl RedisAclHandler {
         self.client.delete(&format!("/v1/redis_acls/{}", uid)).await
     }
 
-    /// Validate an ACL payload - POST /v1/redis_acls/validate (raw)
-    pub async fn validate_raw(&self, body: Value) -> Result<Value> {
+    /// Validate an ACL payload - POST /v1/redis_acls/validate
+    pub async fn validate(&self, body: CreateRedisAclRequest) -> Result<AclValidation> {
         self.client.post("/v1/redis_acls/validate", &body).await
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AclValidation {
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(flatten)]
+    pub extra: Value,
 }

--- a/crates/redis-enterprise/src/services.rs
+++ b/crates/redis-enterprise/src/services.rs
@@ -1,4 +1,8 @@
 //! Service configuration for Redis Enterprise
+//!
+//! Overview
+//! - List/get/update services
+//! - Start/stop/restart, and retrieve service status
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/services.rs
+++ b/crates/redis-enterprise/src/services.rs
@@ -118,4 +118,9 @@ impl ServicesHandler {
             .post(&format!("/v1/services/{}/start", service_id), &Value::Null)
             .await
     }
+
+    /// Create a service - POST /v1/services (raw)
+    pub async fn create_raw(&self, body: Value) -> Result<Service> {
+        self.client.post("/v1/services", &body).await
+    }
 }

--- a/crates/redis-enterprise/src/shards.rs
+++ b/crates/redis-enterprise/src/shards.rs
@@ -108,4 +108,50 @@ impl ShardHandler {
             .get(&format!("/v1/nodes/{}/shards", node_uid))
             .await
     }
+
+    /// Aggregate shard stats - GET /v1/shards/stats
+    pub async fn stats_all_raw(&self) -> Result<Value> {
+        self.client.get("/v1/shards/stats").await
+    }
+
+    /// Aggregate shard stats (last) - GET /v1/shards/stats/last
+    pub async fn stats_all_last_raw(&self) -> Result<Value> {
+        self.client.get("/v1/shards/stats/last").await
+    }
+
+    /// Aggregate shard last stats for specific shard - GET /v1/shards/stats/last/{uid}
+    pub async fn stats_all_last_for_raw(&self, uid: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/shards/stats/last/{}", uid))
+            .await
+    }
+
+    /// Aggregate shard stats for specific shard via alt path - GET /v1/shards/stats/{uid}
+    pub async fn stats_alt_raw(&self, uid: &str) -> Result<Value> {
+        self.client.get(&format!("/v1/shards/stats/{}", uid)).await
+    }
+
+    /// Global failover - POST /v1/shards/actions/failover
+    pub async fn failover_all_raw(&self, body: Value) -> Result<Value> {
+        self.client.post("/v1/shards/actions/failover", &body).await
+    }
+
+    /// Global migrate - POST /v1/shards/actions/migrate
+    pub async fn migrate_all_raw(&self, body: Value) -> Result<Value> {
+        self.client.post("/v1/shards/actions/migrate", &body).await
+    }
+
+    /// Per-shard failover - POST /v1/shards/{uid}/actions/failover
+    pub async fn failover_raw(&self, uid: &str, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/shards/{}/actions/failover", uid), &body)
+            .await
+    }
+
+    /// Per-shard migrate - POST /v1/shards/{uid}/actions/migrate
+    pub async fn migrate_raw(&self, uid: &str, body: Value) -> Result<Value> {
+        self.client
+            .post(&format!("/v1/shards/{}/actions/migrate", uid), &body)
+            .await
+    }
 }

--- a/crates/redis-enterprise/src/shards.rs
+++ b/crates/redis-enterprise/src/shards.rs
@@ -1,4 +1,9 @@
 //! Shard management for Redis Enterprise
+//!
+//! Overview
+//! - List/get shard placement and roles
+//! - Per-shard stats and per-metric time-series
+//! - Failover and migrate actions (global and per-shard) with typed requests
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/stats.rs
+++ b/crates/redis-enterprise/src/stats.rs
@@ -87,10 +87,7 @@ impl StatsHandler {
         self.client.get("/v1/cluster/stats/last").await
     }
 
-    /// Get cluster stats for last interval - raw version
-    pub async fn cluster_last_raw(&self) -> Result<Value> {
-        self.client.get("/v1/cluster/stats/last").await
-    }
+    // raw variant removed: use cluster_last()
 
     /// Get node stats
     pub async fn node(&self, uid: u32, query: Option<StatsQuery>) -> Result<StatsResponse> {
@@ -111,12 +108,7 @@ impl StatsHandler {
             .await
     }
 
-    /// Get node stats for last interval - raw version
-    pub async fn node_last_raw(&self, uid: u32) -> Result<Value> {
-        self.client
-            .get(&format!("/v1/nodes/{}/stats/last", uid))
-            .await
-    }
+    // raw variant removed: use node_last()
 
     /// Get all nodes stats - typed version
     pub async fn nodes(&self, query: Option<StatsQuery>) -> Result<AggregatedStatsResponse> {
@@ -130,27 +122,14 @@ impl StatsHandler {
         }
     }
 
-    /// Get all nodes stats - raw version
-    pub async fn nodes_raw(&self, query: Option<StatsQuery>) -> Result<Value> {
-        if let Some(q) = query {
-            let query_str = serde_urlencoded::to_string(&q).unwrap_or_default();
-            self.client
-                .get(&format!("/v1/nodes/stats?{}", query_str))
-                .await
-        } else {
-            self.client.get("/v1/nodes/stats").await
-        }
-    }
+    // raw variant removed: use nodes()
 
     /// Get all nodes last stats - typed version
     pub async fn nodes_last(&self) -> Result<AggregatedStatsResponse> {
         self.client.get("/v1/nodes/stats/last").await
     }
 
-    /// Get all nodes last stats - raw version
-    pub async fn nodes_last_raw(&self) -> Result<Value> {
-        self.client.get("/v1/nodes/stats/last").await
-    }
+    // raw variant removed: use nodes_last()
 
     /// Get node stats via alternate path form - typed version
     pub async fn node_alt(&self, uid: u32) -> Result<StatsResponse> {
@@ -183,12 +162,7 @@ impl StatsHandler {
             .await
     }
 
-    /// Get database stats for last interval - raw version
-    pub async fn database_last_raw(&self, uid: u32) -> Result<Value> {
-        self.client
-            .get(&format!("/v1/bdbs/{}/stats/last", uid))
-            .await
-    }
+    // raw variant removed: use database_last()
 
     /// Get all databases stats - typed version
     pub async fn databases(&self, query: Option<StatsQuery>) -> Result<AggregatedStatsResponse> {
@@ -202,27 +176,14 @@ impl StatsHandler {
         }
     }
 
-    /// Get all databases stats - raw version
-    pub async fn databases_raw(&self, query: Option<StatsQuery>) -> Result<Value> {
-        if let Some(q) = query {
-            let query_str = serde_urlencoded::to_string(&q).unwrap_or_default();
-            self.client
-                .get(&format!("/v1/bdbs/stats?{}", query_str))
-                .await
-        } else {
-            self.client.get("/v1/bdbs/stats").await
-        }
-    }
+    // raw variant removed: use databases()
 
     /// Get all databases last stats (aggregate) - typed version
     pub async fn databases_last(&self) -> Result<AggregatedStatsResponse> {
         self.client.get("/v1/bdbs/stats/last").await
     }
 
-    /// Get all databases last stats (aggregate) - raw version
-    pub async fn databases_last_raw(&self) -> Result<Value> {
-        self.client.get("/v1/bdbs/stats/last").await
-    }
+    // raw variant removed: use databases_last()
 
     /// Get database stats via alternate path form - typed version
     pub async fn database_alt(&self, uid: u32) -> Result<StatsResponse> {
@@ -260,15 +221,5 @@ impl StatsHandler {
         }
     }
 
-    /// Get all shards stats - raw version
-    pub async fn shards_raw(&self, query: Option<StatsQuery>) -> Result<Value> {
-        if let Some(q) = query {
-            let query_str = serde_urlencoded::to_string(&q).unwrap_or_default();
-            self.client
-                .get(&format!("/v1/shards/stats?{}", query_str))
-                .await
-        } else {
-            self.client.get("/v1/shards/stats").await
-        }
-    }
+    // raw variant removed: use shards()
 }

--- a/crates/redis-enterprise/src/stats.rs
+++ b/crates/redis-enterprise/src/stats.rs
@@ -192,6 +192,28 @@ impl StatsHandler {
         }
     }
 
+    /// Get all databases last stats (aggregate) - typed version
+    pub async fn databases_last(&self) -> Result<AggregatedStatsResponse> {
+        self.client.get("/v1/bdbs/stats/last").await
+    }
+
+    /// Get all databases last stats (aggregate) - raw version
+    pub async fn databases_last_raw(&self) -> Result<Value> {
+        self.client.get("/v1/bdbs/stats/last").await
+    }
+
+    /// Get database stats via alternate path form - typed version
+    pub async fn database_alt(&self, uid: u32) -> Result<StatsResponse> {
+        self.client.get(&format!("/v1/bdbs/stats/{}", uid)).await
+    }
+
+    /// Get database last stats via alternate path form - typed version
+    pub async fn database_last_alt(&self, uid: u32) -> Result<LastStatsResponse> {
+        self.client
+            .get(&format!("/v1/bdbs/stats/last/{}", uid))
+            .await
+    }
+
     /// Get shard stats
     pub async fn shard(&self, uid: u32, query: Option<StatsQuery>) -> Result<StatsResponse> {
         if let Some(q) = query {

--- a/crates/redis-enterprise/src/stats.rs
+++ b/crates/redis-enterprise/src/stats.rs
@@ -142,6 +142,21 @@ impl StatsHandler {
         }
     }
 
+    /// Get all nodes last stats - typed version
+    pub async fn nodes_last(&self) -> Result<AggregatedStatsResponse> {
+        self.client.get("/v1/nodes/stats/last").await
+    }
+
+    /// Get all nodes last stats - raw version
+    pub async fn nodes_last_raw(&self) -> Result<Value> {
+        self.client.get("/v1/nodes/stats/last").await
+    }
+
+    /// Get node stats via alternate path form - typed version
+    pub async fn node_alt(&self, uid: u32) -> Result<StatsResponse> {
+        self.client.get(&format!("/v1/nodes/stats/{}", uid)).await
+    }
+
     /// Get database stats
     pub async fn database(&self, uid: u32, query: Option<StatsQuery>) -> Result<StatsResponse> {
         if let Some(q) = query {

--- a/crates/redis-enterprise/src/stats.rs
+++ b/crates/redis-enterprise/src/stats.rs
@@ -1,4 +1,9 @@
 //! Statistics and metrics for Redis Enterprise
+//!
+//! Overview
+//! - Cluster, node, database, and shard statistics
+//! - Time windows via `StatsQuery` (interval, stime, etime, metrics)
+//! - "last" snapshots for quick health checks
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/stats.rs
+++ b/crates/redis-enterprise/src/stats.rs
@@ -157,6 +157,13 @@ impl StatsHandler {
         self.client.get(&format!("/v1/nodes/stats/{}", uid)).await
     }
 
+    /// Get node last stats via alternate path form - typed version
+    pub async fn node_last_alt(&self, uid: u32) -> Result<LastStatsResponse> {
+        self.client
+            .get(&format!("/v1/nodes/stats/last/{}", uid))
+            .await
+    }
+
     /// Get database stats
     pub async fn database(&self, uid: u32, query: Option<StatsQuery>) -> Result<StatsResponse> {
         if let Some(q) = query {

--- a/crates/redis-enterprise/src/users.rs
+++ b/crates/redis-enterprise/src/users.rs
@@ -169,6 +169,43 @@ impl UserHandler {
     pub async fn delete(&self, uid: u32) -> Result<()> {
         self.client.delete(&format!("/v1/users/{}", uid)).await
     }
+
+    /// Get permissions - GET /v1/users/permissions (raw)
+    pub async fn permissions(&self) -> Result<Value> {
+        self.client.get("/v1/users/permissions").await
+    }
+
+    /// Get permission detail - GET /v1/users/permissions/{perm} (raw)
+    pub async fn permission_detail(&self, perm: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/users/permissions/{}", perm))
+            .await
+    }
+
+    /// Authorize user (login) - POST /v1/users/authorize (raw)
+    pub async fn authorize_raw(&self, body: Value) -> Result<Value> {
+        self.client.post("/v1/users/authorize", &body).await
+    }
+
+    /// Set password - POST /v1/users/password (raw)
+    pub async fn password_set_raw(&self, body: Value) -> Result<Value> {
+        self.client.post("/v1/users/password", &body).await
+    }
+
+    /// Update password - PUT /v1/users/password (raw)
+    pub async fn password_update_raw(&self, body: Value) -> Result<Value> {
+        self.client.put("/v1/users/password", &body).await
+    }
+
+    /// Delete password - DELETE /v1/users/password
+    pub async fn password_delete(&self) -> Result<()> {
+        self.client.delete("/v1/users/password").await
+    }
+
+    /// Refresh JWT - POST /v1/users/refresh_jwt (raw)
+    pub async fn refresh_jwt_raw(&self, body: Value) -> Result<Value> {
+        self.client.post("/v1/users/refresh_jwt", &body).await
+    }
 }
 
 /// Role handler for managing roles

--- a/crates/redis-enterprise/src/users.rs
+++ b/crates/redis-enterprise/src/users.rs
@@ -1,4 +1,24 @@
 //! User and role management for Redis Enterprise
+//!
+//! Overview
+//! - Typed CRUD for users and roles
+//! - Auth flows: authorize, password set/update/delete, JWT refresh
+//! - Permissions discovery helpers
+//!
+//! Example
+//! ```no_run
+//! use redis_enterprise::{EnterpriseClient, UserHandler, CreateUserRequest};
+//!
+//! # async fn ex(client: EnterpriseClient) -> anyhow::Result<()> {
+//! let users = UserHandler::new(client);
+//! let u = users.create(CreateUserRequest::builder()
+//!     .email("dev@example.com")
+//!     .password("secret")
+//!     .role("db_member")
+//!     .build()).await?;
+//! # Ok(())
+//! # }
+//! ```
 
 use crate::client::RestClient;
 use crate::error::Result;

--- a/crates/redis-enterprise/src/users.rs
+++ b/crates/redis-enterprise/src/users.rs
@@ -183,17 +183,17 @@ impl UserHandler {
     }
 
     /// Authorize user (login) - POST /v1/users/authorize (raw)
-    pub async fn authorize_raw(&self, body: Value) -> Result<Value> {
+    pub async fn authorize(&self, body: AuthRequest) -> Result<AuthResponse> {
         self.client.post("/v1/users/authorize", &body).await
     }
 
     /// Set password - POST /v1/users/password (raw)
-    pub async fn password_set_raw(&self, body: Value) -> Result<Value> {
-        self.client.post("/v1/users/password", &body).await
+    pub async fn password_set(&self, body: PasswordSet) -> Result<()> {
+        self.client.post_action("/v1/users/password", &body).await
     }
 
     /// Update password - PUT /v1/users/password (raw)
-    pub async fn password_update_raw(&self, body: Value) -> Result<Value> {
+    pub async fn password_update(&self, body: PasswordUpdate) -> Result<()> {
         self.client.put("/v1/users/password", &body).await
     }
 
@@ -203,9 +203,49 @@ impl UserHandler {
     }
 
     /// Refresh JWT - POST /v1/users/refresh_jwt (raw)
-    pub async fn refresh_jwt_raw(&self, body: Value) -> Result<Value> {
+    pub async fn refresh_jwt(&self, body: JwtRefreshRequest) -> Result<JwtRefreshResponse> {
         self.client.post("/v1/users/refresh_jwt", &body).await
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthResponse {
+    pub jwt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(flatten)]
+    pub extra: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PasswordSet {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PasswordUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_password: Option<String>,
+    pub new_password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JwtRefreshRequest {
+    pub jwt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JwtRefreshResponse {
+    pub jwt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
 }
 
 /// Role handler for managing roles

--- a/crates/redis-enterprise/tests/cluster_tests.rs
+++ b/crates/redis-enterprise/tests/cluster_tests.rs
@@ -215,7 +215,9 @@ async fn test_cluster_reset() {
     Mock::given(method("POST"))
         .and(path("/v1/cluster/actions/reset"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({"status": "cluster_reset"})))
+        .respond_with(success_response(
+            json!({"action_uid": "act-reset-1", "status": "cluster_reset"}),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -227,10 +229,8 @@ async fn test_cluster_reset() {
         .unwrap();
 
     let handler = ClusterHandler::new(client);
-    let result = handler.reset_raw().await;
-
+    let result = handler.reset().await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["status"], "cluster_reset");
 }
 
 #[tokio::test]
@@ -240,7 +240,9 @@ async fn test_cluster_recover() {
     Mock::given(method("POST"))
         .and(path("/v1/cluster/actions/recover"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({"status": "cluster_recovered"})))
+        .respond_with(success_response(
+            json!({"action_uid": "act-recover-1", "status": "cluster_recovered"}),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -252,8 +254,6 @@ async fn test_cluster_recover() {
         .unwrap();
 
     let handler = ClusterHandler::new(client);
-    let result = handler.recover_raw().await;
-
+    let result = handler.recover().await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["status"], "cluster_recovered");
 }

--- a/crates/redis-enterprise/tests/database_tests.rs
+++ b/crates/redis-enterprise/tests/database_tests.rs
@@ -354,3 +354,153 @@ async fn test_database_upgrade() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap()["status"], "upgraded");
 }
+
+#[tokio::test]
+async fn test_database_optimize_shards_placement_status() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/bdbs/1/actions/optimize_shards_placement"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"status": "ok"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = BdbHandler::new(client);
+    let result = handler.optimize_shards_placement(1).await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap()["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_database_recover_post() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/bdbs/1/actions/recover"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"action_uid": "act-1"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = BdbHandler::new(client);
+    let result = handler.recover_raw(1).await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap()["action_uid"], "act-1");
+}
+
+#[tokio::test]
+async fn test_database_peer_and_sync_stats() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/bdbs/1/peer_stats"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"peers": []})))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/bdbs/1/syncer_state"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"state": "ok"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = BdbHandler::new(client);
+    let peers = handler.peer_stats(1).await.unwrap();
+    assert!(peers["peers"].is_array());
+
+    let state = handler.syncer_state(1).await.unwrap();
+    assert_eq!(state["state"], "ok");
+}
+
+#[tokio::test]
+async fn test_bdbs_alerts_and_crdt_detail() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/bdbs/alerts"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!([])))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/bdbs/crdt_sources/alerts/1/2/high_cpu"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"severity": "critical"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = BdbHandler::new(client);
+    let all = handler.alerts_all().await.unwrap();
+    assert!(all.is_array());
+
+    let detail = handler
+        .crdt_source_alert_detail(1, 2, "high_cpu")
+        .await
+        .unwrap();
+    assert_eq!(detail["severity"], "critical");
+}
+
+#[tokio::test]
+async fn test_passwords_delete_and_reset_status() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v1/bdbs/1/passwords"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(no_content_response())
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/bdbs/1/actions/backup_reset_status"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"status": "reset"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = BdbHandler::new(client);
+    handler.passwords_delete(1).await.unwrap();
+    let reset = handler.backup_reset_status(1).await.unwrap();
+    assert_eq!(reset["status"], "reset");
+}

--- a/crates/redis-enterprise/tests/database_tests.rs
+++ b/crates/redis-enterprise/tests/database_tests.rs
@@ -220,10 +220,8 @@ async fn test_database_export() {
         .unwrap();
 
     let handler = BdbHandler::new(client);
-    let result = handler.export_raw(1, "ftp://backup/db1.rdb").await;
-
+    let result = handler.export(1, "ftp://backup/db1.rdb").await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["task_id"], "export-123");
 }
 
 #[tokio::test]
@@ -245,10 +243,8 @@ async fn test_database_import() {
         .unwrap();
 
     let handler = BdbHandler::new(client);
-    let result = handler.import_raw(1, "ftp://backup/db1.rdb", true).await;
-
+    let result = handler.import(1, "ftp://backup/db1.rdb", true).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["task_id"], "import-456");
 }
 
 #[tokio::test]
@@ -270,10 +266,8 @@ async fn test_database_backup() {
         .unwrap();
 
     let handler = BdbHandler::new(client);
-    let result = handler.backup_raw(1).await;
-
+    let result = handler.backup(1).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["backup_id"], "backup-789");
 }
 
 #[tokio::test]
@@ -283,7 +277,9 @@ async fn test_database_restore() {
     Mock::given(method("POST"))
         .and(path("/v1/bdbs/1/actions/restore"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({"status": "restored"})))
+        .respond_with(success_response(
+            json!({"action_uid": "act-restore-1", "status": "restored"}),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -295,10 +291,8 @@ async fn test_database_restore() {
         .unwrap();
 
     let handler = BdbHandler::new(client);
-    let result = handler.restore_raw(1, Some("backup-789")).await;
-
+    let result = handler.restore(1, Some("backup-789")).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["status"], "restored");
 }
 
 #[tokio::test]
@@ -337,7 +331,9 @@ async fn test_database_upgrade() {
     Mock::given(method("POST"))
         .and(path("/v1/bdbs/1/actions/upgrade"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({"status": "upgraded"})))
+        .respond_with(success_response(
+            json!({"action_uid": "act-up-1", "status": "upgraded"}),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -349,10 +345,8 @@ async fn test_database_upgrade() {
         .unwrap();
 
     let handler = BdbHandler::new(client);
-    let result = handler.upgrade_raw(1, "search", "2.0").await;
-
+    let result = handler.upgrade(1, "search", "2.0").await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["status"], "upgraded");
 }
 
 #[tokio::test]
@@ -399,10 +393,9 @@ async fn test_database_recover_post() {
         .unwrap();
 
     let handler = BdbHandler::new(client);
-    let result = handler.recover_raw(1).await;
-
+    let result = handler.recover(1).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap()["action_uid"], "act-1");
+    assert_eq!(result.unwrap().action_uid, "act-1");
 }
 
 #[tokio::test]

--- a/crates/redis-enterprise/tests/node_tests.rs
+++ b/crates/redis-enterprise/tests/node_tests.rs
@@ -558,12 +558,8 @@ async fn test_node_execute_action_maintenance_on() {
         .unwrap();
 
     let handler = NodeHandler::new(client);
-    let result = handler.execute_action_raw(1, "maintenance_on").await;
-
-    assert!(result.is_ok());
-    let response = result.unwrap();
-    assert_eq!(response["action_uid"], "action-123-abc");
-    assert_eq!(response["status"], "pending");
+    let response = handler.execute_action(1, "maintenance_on").await.unwrap();
+    assert_eq!(response.action_uid, "action-123-abc");
 }
 
 #[tokio::test]
@@ -595,12 +591,8 @@ async fn test_node_execute_action_maintenance_off() {
         .unwrap();
 
     let handler = NodeHandler::new(client);
-    let result = handler.execute_action_raw(1, "maintenance_off").await;
-
-    assert!(result.is_ok());
-    let response = result.unwrap();
-    assert_eq!(response["action_uid"], "action-456-def");
-    assert_eq!(response["status"], "completed");
+    let response = handler.execute_action(1, "maintenance_off").await.unwrap();
+    assert_eq!(response.action_uid, "action-456-def");
 }
 
 #[tokio::test]
@@ -628,7 +620,7 @@ async fn test_node_execute_action_invalid() {
         .unwrap();
 
     let handler = NodeHandler::new(client);
-    let result = handler.execute_action_raw(1, "invalid_action").await;
+    let result = handler.execute_action(1, "invalid_action").await;
 
     assert!(result.is_err());
 }
@@ -658,7 +650,7 @@ async fn test_node_execute_action_nonexistent_node() {
         .unwrap();
 
     let handler = NodeHandler::new(client);
-    let result = handler.execute_action_raw(999, "restart").await;
+    let result = handler.execute_action(999, "restart").await;
 
     assert!(result.is_err());
 }

--- a/crates/redis-enterprise/tests/node_tests.rs
+++ b/crates/redis-enterprise/tests/node_tests.rs
@@ -39,6 +39,114 @@ fn test_node() -> serde_json::Value {
     })
 }
 
+#[tokio::test]
+async fn test_node_actions_alerts_and_status() {
+    let mock_server = MockServer::start().await;
+
+    // Global actions
+    Mock::given(method("GET"))
+        .and(path("/v1/nodes/actions"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!(["maintenance_on"])))
+        .mount(&mock_server)
+        .await;
+
+    // Alerts
+    Mock::given(method("GET"))
+        .and(path("/v1/nodes/alerts/1"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!([{"name": "high_cpu"}])))
+        .mount(&mock_server)
+        .await;
+
+    // Status
+    Mock::given(method("GET"))
+        .and(path("/v1/nodes/1/status"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"status": "ok"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = NodeHandler::new(client);
+    let acts = handler.list_actions().await.unwrap();
+    assert!(acts.is_array());
+
+    let alerts = handler.alerts_for(1).await.unwrap();
+    assert!(alerts.is_array());
+
+    let stat = handler.status(1).await.unwrap();
+    assert_eq!(stat["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_node_snapshots_and_action_paths() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/nodes/1/snapshots"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!(["s1"])))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/nodes/1/snapshots/s1"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"created": true})))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v1/nodes/1/snapshots/s1"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(no_content_response())
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/nodes/1/actions/maintenance_on"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"action_uid": "a1"})))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v1/nodes/1/actions/maintenance_on"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(no_content_response())
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = NodeHandler::new(client);
+
+    let snaps = handler.snapshots(1).await.unwrap();
+    assert!(snaps.is_array());
+
+    handler.snapshot_create(1, "s1").await.unwrap();
+    handler.snapshot_delete(1, "s1").await.unwrap();
+
+    let r = handler
+        .action_execute(1, "maintenance_on", serde_json::json!({}))
+        .await
+        .unwrap();
+    assert_eq!(r["action_uid"], "a1");
+    handler.action_delete(1, "maintenance_on").await.unwrap();
+}
+
 fn test_slave_node() -> serde_json::Value {
     json!({
         "uid": 2,

--- a/crates/redis-enterprise/tests/proxy_tests.rs
+++ b/crates/redis-enterprise/tests/proxy_tests.rs
@@ -285,16 +285,13 @@ async fn test_proxy_stats_metric() {
         .unwrap();
 
     let handler = ProxyHandler::new(client);
-    let result = handler.stats_metric_raw(1, "connections").await;
-
-    assert!(result.is_ok());
-    let metric_stats = result.unwrap();
-    assert_eq!(metric_stats["interval"], "1sec");
-    assert_eq!(metric_stats["timestamps"].as_array().unwrap().len(), 3);
-    assert_eq!(metric_stats["values"].as_array().unwrap().len(), 3);
-    assert_eq!(metric_stats["values"][0], 25);
-    assert_eq!(metric_stats["values"][1], 30);
-    assert_eq!(metric_stats["values"][2], 28);
+    let metric_stats = handler.stats_metric(1, "connections").await.unwrap();
+    assert_eq!(metric_stats.interval, "1sec");
+    assert_eq!(metric_stats.timestamps.len(), 3);
+    assert_eq!(metric_stats.values.len(), 3);
+    assert_eq!(metric_stats.values[0], 25);
+    assert_eq!(metric_stats.values[1], 30);
+    assert_eq!(metric_stats.values[2], 28);
 }
 
 #[tokio::test]
@@ -320,13 +317,10 @@ async fn test_proxy_stats_metric_ops() {
         .unwrap();
 
     let handler = ProxyHandler::new(client);
-    let result = handler.stats_metric_raw(2, "ops_per_sec").await;
-
-    assert!(result.is_ok());
-    let metric_stats = result.unwrap();
-    assert_eq!(metric_stats["interval"], "1min");
-    assert_eq!(metric_stats["values"][0], 162.0);
-    assert_eq!(metric_stats["values"][1], 168.0);
+    let metric_stats = handler.stats_metric(2, "ops_per_sec").await.unwrap();
+    assert_eq!(metric_stats.interval, "1min");
+    assert_eq!(metric_stats.values[0], 162.0);
+    assert_eq!(metric_stats.values[1], 168.0);
 }
 
 #[tokio::test]
@@ -548,8 +542,7 @@ async fn test_proxy_stats_metric_invalid() {
         .unwrap();
 
     let handler = ProxyHandler::new(client);
-    let result = handler.stats_metric_raw(1, "invalid_metric").await;
-
+    let result = handler.stats_metric(1, "invalid_metric").await;
     assert!(result.is_err());
 }
 

--- a/crates/redis-enterprise/tests/shard_tests.rs
+++ b/crates/redis-enterprise/tests/shard_tests.rs
@@ -322,14 +322,13 @@ async fn test_shard_stats_metric() {
         .unwrap();
 
     let handler = ShardHandler::new(client);
-    let result = handler.stats_metric_raw("shard:1:1", "ops_per_sec").await;
-
-    assert!(result.is_ok());
-    let metric_stats = result.unwrap();
-    assert_eq!(metric_stats["interval"], "1sec");
-    assert_eq!(metric_stats["timestamps"].as_array().unwrap().len(), 3);
-    assert_eq!(metric_stats["values"].as_array().unwrap().len(), 3);
-    assert_eq!(metric_stats["values"][0], 1250.5);
+    let metric_stats = handler
+        .stats_metric("shard:1:1", "ops_per_sec")
+        .await
+        .unwrap();
+    assert_eq!(metric_stats.interval, "1sec");
+    assert_eq!(metric_stats.timestamps.len(), 3);
+    assert_eq!(metric_stats.values.len(), 3);
 }
 
 #[tokio::test]
@@ -355,13 +354,13 @@ async fn test_shard_stats_metric_memory() {
         .unwrap();
 
     let handler = ShardHandler::new(client);
-    let result = handler.stats_metric_raw("shard:2:1", "memory_usage").await;
-
-    assert!(result.is_ok());
-    let metric_stats = result.unwrap();
-    assert_eq!(metric_stats["interval"], "1min");
-    assert_eq!(metric_stats["values"][0], 1048576);
-    assert_eq!(metric_stats["values"][1], 1052000);
+    let metric_stats = handler
+        .stats_metric("shard:2:1", "memory_usage")
+        .await
+        .unwrap();
+    assert_eq!(metric_stats.interval, "1min");
+    assert_eq!(metric_stats.values[0], 1048576);
+    assert_eq!(metric_stats.values[1], 1052000);
 }
 
 #[tokio::test]
@@ -564,9 +563,6 @@ async fn test_shard_stats_metric_invalid() {
         .unwrap();
 
     let handler = ShardHandler::new(client);
-    let result = handler
-        .stats_metric_raw("shard:1:1", "invalid_metric")
-        .await;
-
+    let result = handler.stats_metric("shard:1:1", "invalid_metric").await;
     assert!(result.is_err());
 }

--- a/scripts/check-api-coverage.py
+++ b/scripts/check-api-coverage.py
@@ -61,11 +61,12 @@ def find_api_calls(handler_path: Path) -> Dict[str, Set[Tuple[str, str]]]:
         
         # Find all client.get/post/put/delete/patch calls
         patterns = [
-            r'\.get\(&format!\("([^"]+)"',
-            r'\.post\(&format!\("([^"]+)"',
-            r'\.put\(&format!\("([^"]+)"',
-            r'\.delete\(&format!\("([^"]+)"',
-            r'\.patch\(&format!\("([^"]+)"',
+            # Allow whitespace/newlines between '(' and &format!
+            r'\.get\(\s*&format!\(\s*"([^"]+)"',
+            r'\.post\(\s*&format!\(\s*"([^"]+)"',
+            r'\.put\(\s*&format!\(\s*"([^"]+)"',
+            r'\.delete\(\s*&format!\(\s*"([^"]+)"',
+            r'\.patch\(\s*&format!\(\s*"([^"]+)"',
             r'\.get\("([^"]+)"\)',
             r'\.post\("([^"]+)"',
             r'\.put\("([^"]+)"',

--- a/scripts/check-api-coverage.py
+++ b/scripts/check-api-coverage.py
@@ -2,15 +2,24 @@
 """
 API Coverage Checker for Redis Enterprise and Redis Cloud
 
-This script analyzes the handler implementations to determine API coverage
-by comparing implemented methods against known API endpoints.
+Enhanced to parse the local Redis Enterprise REST routing table (HTML) and
+compare code endpoints against documented ones. By default, only /v1 and /v2
+endpoints are considered for coverage (legacy /crdbs and /crdb_tasks are
+excluded). Use this to identify missing endpoints and track progress toward
+100% API coverage.
+
+Optional dependencies: none (HTML parsed via regex). BeautifulSoup/lxml are not
+required.
 """
 
 import os
 import re
 import json
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Iterable
+
+import argparse
+import sys
 
 def find_handler_methods(handler_path: Path) -> Dict[str, List[str]]:
     """Find all public async functions in handler files."""
@@ -50,16 +59,18 @@ def find_api_calls(handler_path: Path) -> Dict[str, Set[Tuple[str, str]]]:
         handler_name = handler_file.stem
         endpoints = set()
         
-        # Find all client.get/post/put/delete calls
+        # Find all client.get/post/put/delete/patch calls
         patterns = [
             r'\.get\(&format!\("([^"]+)"',
             r'\.post\(&format!\("([^"]+)"',
             r'\.put\(&format!\("([^"]+)"',
             r'\.delete\(&format!\("([^"]+)"',
+            r'\.patch\(&format!\("([^"]+)"',
             r'\.get\("([^"]+)"\)',
             r'\.post\("([^"]+)"',
             r'\.put\("([^"]+)"',
             r'\.delete\("([^"]+)"',
+            r'\.patch\("([^"]+)"',
         ]
         
         for pattern in patterns:
@@ -74,6 +85,8 @@ def find_api_calls(handler_path: Path) -> Dict[str, Set[Tuple[str, str]]]:
                     method = 'PUT'
                 elif 'delete' in pattern:
                     method = 'DELETE'
+                elif 'patch' in pattern:
+                    method = 'PATCH'
                 endpoints.add((method, match))
                 
         api_calls[handler_name] = endpoints
@@ -124,8 +137,64 @@ def check_dual_interface(typed_coverage: Dict[str, Dict[str, bool]]) -> Dict[str
             
     return violations
 
+
+def normalize_path(path: str, drop_query: bool = True) -> str:
+    """Normalize endpoint path placeholders to a canonical form for comparison."""
+    # Replace Rust format placeholders and doc placeholders with {}
+    path = re.sub(r"\{[^\}]+\}", "{}", path)
+    path = re.sub(r"\((?:int:)?[^\)]+\)", "{}", path)
+    # Normalize duplicate slashes
+    path = re.sub(r"//+", "/", path)
+    if drop_query:
+        path = path.split("?")[0]
+    return path
+
+
+def parse_routing_table_html(html_path: Path) -> Set[Tuple[str, str]]:
+    """Parse documented endpoints from the local routing table HTML using regex only.
+
+    Returns a set of (METHOD, PATH) tuples.
+    """
+    if not html_path.exists():
+        return set()
+    html = html_path.read_text(errors="ignore")
+    # Match <code class="xref">GET /v1/...</code>
+    pattern = re.compile(r'<code class="xref">\s*([A-Z]+)\s+([^<]+?)\s*</code>')
+    endpoints: Set[Tuple[str, str]] = set()
+    for method, path in pattern.findall(html):
+        endpoints.add((method, normalize_path(path)))
+    return endpoints
+
+
+def filter_scope(endpoints: Iterable[Tuple[str, str]], include_v2: bool = True) -> Set[Tuple[str, str]]:
+    """Keep only /v1 and (optionally) /v2 endpoints. Excludes legacy /crdbs, /crdb_tasks."""
+    scoped: Set[Tuple[str, str]] = set()
+    for method, path in endpoints:
+        if path.startswith("/v1/"):
+            scoped.add((method, path))
+        elif include_v2 and path.startswith("/v2/"):
+            scoped.add((method, path))
+        # else: skip legacy or other roots
+    return scoped
+
+
+def group_by_category(endpoints: Iterable[Tuple[str, str]]) -> Dict[str, List[Tuple[str, str]]]:
+    """Group endpoints by category (the first segment after /v1/ or /v2/)."""
+    grouped: Dict[str, List[Tuple[str, str]]] = {}
+    for method, path in endpoints:
+        root = "unknown"
+        if path.startswith("/v1/") or path.startswith("/v2/"):
+            root = path.split("/")[2]
+        grouped.setdefault(root, []).append((method, path))
+    return grouped
+
 def main():
     """Main function to analyze API coverage."""
+    parser = argparse.ArgumentParser(description="API coverage analyzer")
+    parser.add_argument("--fail-on-gaps", action="store_true", help="Exit non-zero if gaps exist in scoped endpoints")
+    parser.add_argument("--routing-table", default="tmp/rest-html/http-routingtable.html", help="Path to routing table HTML")
+    parser.add_argument("--scope", choices=["v1", "v1v2"], default="v1v2", help="Endpoint scope to require coverage for")
+    args = parser.parse_args()
     # Paths to handler directories
     enterprise_handlers = Path("crates/redis-enterprise/src")
     cloud_handlers = Path("crates/redis-cloud/src/handlers")
@@ -153,7 +222,7 @@ def main():
         total_endpoints = sum(len(e) for e in api_calls.values())
         
         print(f"Total methods: {total_methods}")
-        print(f"Total unique API endpoints: {total_endpoints}")
+        print(f"Total unique API endpoints (from code): {total_endpoints}")
         
         # Check for dual interface violations
         violations = check_dual_interface(typed_coverage)
@@ -165,12 +234,55 @@ def main():
                     print(f"    - {issue}")
         
         # List all endpoints
-        print("\n### API Endpoints by Handler:")
+        print("\n### API Endpoints by Handler (from code):")
         for handler, endpoints in sorted(api_calls.items()):
             if endpoints:
                 print(f"\n  {handler}:")
                 for method, endpoint in sorted(endpoints):
                     print(f"    {method:6} {endpoint}")
+
+        # Compare with documented endpoints (scoped)
+        print("\n---\n")
+        print("### Documentation Diff (scoped)")
+        rt_path = Path(args.routing_table)
+        doc_endpoints_all = parse_routing_table_html(rt_path)
+        if not doc_endpoints_all:
+            print(f"Routing table not found at {rt_path}; skipping doc diff.")
+        else:
+            include_v2 = args.scope == "v1v2"
+            doc_scoped = filter_scope(doc_endpoints_all, include_v2=include_v2)
+
+            # Normalize code endpoints similarly and scope to v1/v2
+            code_eps: Set[Tuple[str, str]] = set()
+            for handler, eps in api_calls.items():
+                for method, endpoint in eps:
+                    norm = normalize_path(endpoint)
+                    # Only keep v1/v2
+                    if norm.startswith("/v1/") or (include_v2 and norm.startswith("/v2/")):
+                        code_eps.add((method, norm))
+
+            missing = sorted(doc_scoped - code_eps)
+            extra = sorted(code_eps - doc_scoped)
+
+            print(f"Scoped documented endpoints: {len(doc_scoped)}")
+            print(f"Scoped code endpoints:       {len(code_eps)}")
+            print(f"Missing in code:             {len(missing)}")
+            print(f"Extra in code:               {len(extra)}")
+
+            # Group missing by category
+            if missing:
+                print("\n#### Missing by Category:")
+                by_cat = group_by_category(missing)
+                for cat in sorted(by_cat.keys()):
+                    print(f"- {cat}: {len(by_cat[cat])}")
+                    for m, p in by_cat[cat][:6]:
+                        print(f"    {m:6} {p}")
+                    if len(by_cat[cat]) > 6:
+                        print("    ...")
+
+            if args.fail_on_gaps and missing:
+                print("\nCoverage gaps detected.", file=sys.stderr)
+                sys.exit(1)
     
     # Analyze Cloud
     if cloud_handlers.exists():


### PR DESCRIPTION
This PR tracks and delivers a full audit + modernization of the Redis Cloud client to match the Enterprise style:

Goals
- 100% coverage of documented endpoints (OpenAPI) where applicable
- Fully typed handlers (remove `_raw`), with minimal Value usage only where truly necessary
- Clear versioning where Redis Cloud exposes multiple API namespaces
- Tests and docs aligned with typed + versioned usage

Initial Audit (OpenAPI vs code)
- Source: https://redis.io/docs/latest/operate/rc/api/api-reference/openapi.json
- OpenAPI unique endpoints parsed: 130
- Code unique endpoints detected: 169
- Gaps: 63 missing, 102 extra (naming/paths/parity to reconcile)
- Missing samples (by category):
  - fixed: subscriptions delete, database delete/tag routes, redis-versions, plans, database backup/import/slow-log/tags
  - subscriptions: database tags (GET/DELETE), certificate/import/slow-log/upgrade, maintenance-windows, cidr
  - logs: /logs, /session-logs
  - private-service-connect: top-level and regional delete/endpoint deletes
  - regions: /regions
  - cloud-accounts: GET/DELETE coverage
  - data-persistence, database-modules, query-performance-factors

Plan
1) Normalize handler paths to match OpenAPI (use exact URIs)
2) Convert handlers to typed-only (remove `_raw`); add request/response models
3) Add missing endpoints per OpenAPI; write wiremock tests (success/error)
4) Add concise module-level docs; keep examples simple
5) Optional: add OpenAPI-driven coverage check for Cloud similar to Enterprise

Versioning
- If multiple versions/namespaces exist, introduce versioned sub-handlers as done for Enterprise (e.g., handler.v1())

Follow-ups
- After Cloud typed refactor and tests pass, we’ll open a PR to clean up the CLI to serialize typed responses, and optionally wire coverage in CI
