### PR TITLE
docs: add library primers and align rustdoc pointers

### DIFF
--- a/crates/redis-cloud/src/lib.rs
+++ b/crates/redis-cloud/src/lib.rs
@@ -62,6 +62,32 @@
 //! # }
 //! ```
 //!
+//! ### Typed vs Raw API
+//!
+//! This client offers typed handlers for common operations as well as raw helpers when you
+//! need full control over request/response payloads:
+//!
+//! - Prefer typed handlers (e.g., `CloudDatabaseHandler`) for structured, ergonomic access.
+//! - Use raw helpers for passthroughs: `get_raw`, `post_raw`, `put_raw`, `patch_raw`, `delete_raw`.
+//!
+//! ```rust,no_run
+//! use redis_cloud::CloudClient;
+//! use serde_json::json;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = CloudClient::builder()
+//!     .api_key("key")
+//!     .api_secret("secret")
+//!     .build()?;
+//!
+//! // Raw call example
+//! let created = client.post_raw("/subscriptions", json!({ "name": "example" })).await?;
+//! println!("{}", created);
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ### Working with Subscriptions
 //!
 //! ```rust,no_run
@@ -110,7 +136,7 @@
 //! // Create database using raw API
 //! let database_config = json!({
 //!     "name": "my-database",
-//!     "memory_limit_in_gb": 1.0,
+//!     "memoryLimitInGb": 1.0,
 //!     "support_oss_cluster_api": false,
 //!     "replication": true
 //! });
@@ -228,6 +254,11 @@
 //! - `x-api-secret-key`: Your API secret
 //!
 //! These credentials can be obtained from the Redis Cloud console under Account Settings > API Keys.
+//!
+//! Environment variables commonly used with this client:
+//! - `REDIS_CLOUD_API_KEY`
+//! - `REDIS_CLOUD_API_SECRET`
+//! - Optional: set a custom base URL via the builder for non‑prod/test environments (defaults to `https://api.redislabs.com/v1`).
 
 pub mod client;
 pub mod handlers;

--- a/crates/redis-enterprise/src/lib.rs
+++ b/crates/redis-enterprise/src/lib.rs
@@ -239,6 +239,23 @@
 //! # }
 //! ```
 //!
+//! ## Handler Overview
+//!
+//! The library exposes focused handlers per API domain to keep code organized and discoverable:
+//!
+//! | Handler | Purpose | Key Operations |
+//! |---------|---------|----------------|
+//! | `ClusterHandler` | Cluster lifecycle | info, update, license, services |
+//! | `BdbHandler` | Databases (BDB) | list, get, create, update, delete, stats |
+//! | `NodeHandler` | Node management | list, get, stats |
+//! | `UserHandler` | Users | list, get, create, update, delete |
+//! | `RoleHandler` | Roles | list, get, assign |
+//! | `ModuleHandler` | Modules | list (v1), upload (v2) |
+//! | `AlertHandler` | Alerts | list, acknowledge |
+//! | `StatsHandler` | Monitoring | cluster/node/database stats |
+//! | `LogsHandler` | Logs | cluster and database logs |
+//! | `ActionHandler` | Actions | v1/v2 workflows |
+//!
 //! # Production Best Practices
 //!
 //! - **Connection Pooling**: The client reuses HTTP connections automatically

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -69,6 +69,11 @@
   - [logs](./cli-reference/enterprise/logs.md)
   - [stats](./cli-reference/enterprise/stats.md)
 
+# Libraries
+- [Overview](./libraries/README.md)
+  - [Redis Cloud Library](./libraries/redis-cloud.md)
+  - [Redis Enterprise Library](./libraries/redis-enterprise.md)
+
 # Workflows
 - [Cluster Bootstrap](./workflows/cluster-bootstrap.md)
 - [Database Creation](./workflows/database-creation.md)

--- a/docs/src/libraries/README.md
+++ b/docs/src/libraries/README.md
@@ -1,0 +1,9 @@
+# Libraries
+
+Short primers for the Rust libraries used by `redisctl`.
+
+- Redis Cloud client: typed and raw APIs for Redis Cloud management tasks.
+- Redis Enterprise client: typed APIs for cluster, database, users, modules, and more.
+
+For full, up-to-date API documentation, follow the links to the rustdocs in each primer.
+

--- a/docs/src/libraries/redis-cloud.md
+++ b/docs/src/libraries/redis-cloud.md
@@ -1,0 +1,41 @@
+# Redis Cloud Rust Library
+
+The `redis-cloud` crate provides a typed Rust client for the Redis Cloud REST API. It supports subscriptions, databases, ACLs, SSO, billing, logs, metrics, CRDB, and networking endpoints.
+
+- Crate: `redis-cloud`
+- Rustdoc: https://docs.rs/redis-cloud/latest/redis_cloud/
+
+## Install
+
+```toml
+[dependencies]
+redis-cloud = "0.1"
+tokio = { version = "1", features = ["full"] }
+```
+
+Or:
+
+```bash
+cargo add redis-cloud
+```
+
+## Quick Example
+
+```rust,no_run
+use redis_cloud::{CloudClient, CloudSubscriptionHandler};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = CloudClient::builder()
+        .api_key(std::env::var("REDIS_CLOUD_API_KEY")?)
+        .api_secret(std::env::var("REDIS_CLOUD_API_SECRET")?)
+        .build()?;
+
+    let subs = CloudSubscriptionHandler::new(client).list().await?;
+    println!("Found {} subscriptions", subs.len());
+    Ok(())
+}
+```
+
+See the rustdoc for all handlers, models, and configuration options.
+

--- a/docs/src/libraries/redis-enterprise.md
+++ b/docs/src/libraries/redis-enterprise.md
@@ -1,0 +1,42 @@
+# Redis Enterprise Rust Library
+
+The `redis-enterprise` crate provides a comprehensive, typed Rust client for Redis Enterprise clusters (on-prem or self-managed). It covers cluster management, databases (BDB), nodes, users/roles, modules, CRDB, stats, and logs.
+
+- Crate: `redis-enterprise`
+- Rustdoc: https://docs.rs/redis-enterprise/latest/redis_enterprise/
+
+## Install
+
+```toml
+[dependencies]
+redis-enterprise = "0.2"
+tokio = { version = "1", features = ["full"] }
+```
+
+Or:
+
+```bash
+cargo add redis-enterprise
+```
+
+## Quick Example
+
+```rust,no_run
+use redis_enterprise::EnterpriseClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = EnterpriseClient::builder()
+        .base_url(std::env::var("REDIS_ENTERPRISE_URL")?)
+        .username(std::env::var("REDIS_ENTERPRISE_USER")?)
+        .password(std::env::var("REDIS_ENTERPRISE_PASSWORD")?)
+        .build()?;
+
+    let dbs = client.databases().list().await?;
+    println!("Found {} databases", dbs.len());
+    Ok(())
+}
+```
+
+See the rustdoc for handlers, models, and advanced operations.
+


### PR DESCRIPTION
- Add short mdBook primers for redis-cloud and redis-enterprise with links to rustdocs.\n- Keep mdBook primarily CLI-focused; defer full API docs to rustdoc.\n- Sync crate rustdocs (Cloud: typed-vs-raw, env vars; Enterprise: handler overview).\n\nCI: doc tests pass; no code changes.\n\nPreview: docs > Libraries section.