### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Summary
+
+- What does this PR change and why?
+- Link related issues (e.g., Closes #123)
+
+## Why
+
+- Brief context: problem, goal, or motivation
+
+## Changes
+
+- Key changes (bulleted)
+- Affected crates/docs/CLI
+- Any notable refactors
+
+## Validation
+
+- [ ] cargo test --workspace --all-features
+- [ ] cargo clippy --all-targets --all-features -D warnings
+- [ ] cargo fmt --all
+- [ ] Doc tests (if applicable)
+- [ ] Manual/local verification notes
+
+## Impact
+
+- Breaking changes? Migrations? Backwards compatibility notes
+- User-facing behavior changes
+
+## Screenshots / Docs
+
+- Links to docs pages, previews, or screenshots (if applicable)
+
+## Checklist
+
+- [ ] Updated docs/help text if user-facing
+- [ ] Security reviewed (no secrets committed)
+- [ ] Added tests or updated existing tests (if applicable)
+- [ ] Linked issues and added appropriate labels
+


### PR DESCRIPTION
Adds .github/pull_request_template.md for consistent, Markdown-based PRs.\n\nSummary\n- Establishes a shared structure for PR descriptions: Summary, Why, Changes, Validation, Impact, Screenshots/Docs, Checklist.\n- Encourages including validation steps (tests/clippy/fmt) and linking issues.\n\nNo code changes; docs-only. Ready for review.