### PR TITLE
test(redis-cloud): comprehensive test coverage for account, ACL, and cloud accounts handlers

### DIFF
--- a/crates/redis-cloud/tests/account_tests.rs
+++ b/crates/redis-cloud/tests/account_tests.rs
@@ -248,7 +248,335 @@ async fn test_get_account_system_logs() {
 }
 
 #[tokio::test]
-async fn test_error_handling() {
+async fn test_get_supported_search_scaling_factors() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/query-performance-factors"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "queryPerformanceFactors": [
+                "low",
+                "medium",
+                "high"
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler
+        .get_supported_search_scaling_factors()
+        .await
+        .unwrap();
+
+    assert!(result.query_performance_factors.is_some());
+    let factors = result.query_performance_factors.unwrap();
+    assert_eq!(factors.len(), 3);
+    assert_eq!(factors[0], "low");
+    assert_eq!(factors[1], "medium");
+    assert_eq!(factors[2], "high");
+}
+
+#[tokio::test]
+async fn test_get_account_session_logs() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/session-logs"))
+        .and(query_param("limit", "10"))
+        .and(query_param("offset", "5"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "entries": [
+                {
+                    "id": "session-123",
+                    "time": "2024-01-01T12:00:00Z",
+                    "user": "admin@example.com",
+                    "userAgent": "Mozilla/5.0",
+                    "ipAddress": "192.168.1.1",
+                    "userRole": "Admin",
+                    "type": "login",
+                    "action": "successful_login"
+                },
+                {
+                    "id": "session-124",
+                    "time": "2024-01-01T12:05:00Z",
+                    "user": "user@example.com",
+                    "userAgent": "curl/7.68.0",
+                    "ipAddress": "10.0.0.1",
+                    "userRole": "Member",
+                    "type": "logout",
+                    "action": "session_terminated"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler
+        .get_account_session_logs(Some(5), Some(10))
+        .await
+        .unwrap();
+
+    assert!(result.entries.is_some());
+    let entries = result.entries.unwrap();
+    assert_eq!(entries.len(), 2);
+
+    let first_entry = &entries[0];
+    assert_eq!(first_entry.id.as_ref().unwrap(), "session-123");
+    assert_eq!(first_entry.user.as_ref().unwrap(), "admin@example.com");
+    assert_eq!(first_entry.user_role.as_ref().unwrap(), "Admin");
+    assert_eq!(first_entry.r#type.as_ref().unwrap(), "login");
+
+    let second_entry = &entries[1];
+    assert_eq!(second_entry.id.as_ref().unwrap(), "session-124");
+    assert_eq!(second_entry.user.as_ref().unwrap(), "user@example.com");
+    assert_eq!(second_entry.user_role.as_ref().unwrap(), "Member");
+    assert_eq!(second_entry.r#type.as_ref().unwrap(), "logout");
+}
+
+#[tokio::test]
+async fn test_get_account_session_logs_no_params() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/session-logs"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "entries": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_account_session_logs(None, None).await.unwrap();
+
+    assert!(result.entries.is_some());
+    let entries = result.entries.unwrap();
+    assert_eq!(entries.len(), 0);
+}
+
+#[tokio::test]
+async fn test_get_supported_regions_no_provider() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/regions"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "regions": [
+                {
+                    "name": "us-east-1",
+                    "provider": "AWS"
+                },
+                {
+                    "name": "us-central1",
+                    "provider": "GCP"
+                },
+                {
+                    "name": "East US",
+                    "provider": "Azure"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_supported_regions(None).await.unwrap();
+
+    assert!(result.regions.is_some());
+    let regions = result.regions.unwrap();
+    assert_eq!(regions.len(), 3);
+
+    let providers: Vec<String> = regions
+        .iter()
+        .map(|r| r.provider.clone().unwrap_or_default())
+        .collect();
+    assert!(providers.contains(&"AWS".to_string()));
+    assert!(providers.contains(&"GCP".to_string()));
+    assert!(providers.contains(&"Azure".to_string()));
+}
+
+#[tokio::test]
+async fn test_get_account_system_logs_no_params() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/logs"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "entries": [
+                {
+                    "id": 100,
+                    "time": "2024-01-01T10:00:00Z",
+                    "originator": "API",
+                    "apiKeyName": "production-api-key",
+                    "resource": "subscription/123",
+                    "type": "create",
+                    "description": "Subscription created successfully"
+                },
+                {
+                    "id": 101,
+                    "time": "2024-01-01T10:05:00Z",
+                    "originator": "User",
+                    "resource": "database/456",
+                    "type": "delete",
+                    "description": "Database deleted"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_account_system_logs(None, None).await.unwrap();
+
+    assert!(result.entries.is_some());
+    let entries = result.entries.unwrap();
+    assert_eq!(entries.len(), 2);
+
+    let first_entry = &entries[0];
+    assert_eq!(first_entry.id.unwrap(), 100);
+    assert_eq!(first_entry.originator.as_ref().unwrap(), "API");
+    assert_eq!(
+        first_entry.api_key_name.as_ref().unwrap(),
+        "production-api-key"
+    );
+    assert_eq!(first_entry.resource.as_ref().unwrap(), "subscription/123");
+    assert_eq!(first_entry.r#type.as_ref().unwrap(), "create");
+
+    let second_entry = &entries[1];
+    assert_eq!(second_entry.id.unwrap(), 101);
+    assert_eq!(second_entry.originator.as_ref().unwrap(), "User");
+    assert_eq!(second_entry.resource.as_ref().unwrap(), "database/456");
+    assert_eq!(second_entry.r#type.as_ref().unwrap(), "delete");
+}
+
+#[tokio::test]
+async fn test_get_supported_database_modules_empty() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/database-modules"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "modules": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_supported_database_modules().await.unwrap();
+
+    assert!(result.modules.is_some());
+    let modules = result.modules.unwrap();
+    assert_eq!(modules.len(), 0);
+}
+
+#[tokio::test]
+async fn test_get_data_persistence_options_with_links() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/data-persistence"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "dataPersistence": [
+                {
+                    "name": "aof-every-1-sec",
+                    "description": "Append only file (AOF) - fsync every 1 second"
+                }
+            ],
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "https://api.redislabs.com/v1/data-persistence",
+                    "type": "GET"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_data_persistence_options().await.unwrap();
+
+    assert!(result.data_persistence.is_some());
+    assert!(result.links.is_some());
+    let persistence_options = result.data_persistence.unwrap();
+    assert_eq!(persistence_options.len(), 1);
+    assert_eq!(
+        persistence_options[0].name.as_ref().unwrap(),
+        "aof-every-1-sec"
+    );
+
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 1);
+}
+
+// Error handling tests
+
+#[tokio::test]
+async fn test_error_handling_401() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
@@ -273,5 +601,111 @@ async fn test_error_handling() {
     match result {
         Err(redis_cloud::CloudError::AuthenticationFailed { .. }) => {}
         _ => panic!("Expected AuthenticationFailed error"),
+    }
+}
+
+#[tokio::test]
+async fn test_error_handling_404() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/regions"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": "Resource not found"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_supported_regions(None).await;
+
+    assert!(result.is_err());
+    match result {
+        Err(redis_cloud::CloudError::NotFound { .. }) => {}
+        _ => panic!("Expected NotFound error"),
+    }
+}
+
+#[tokio::test]
+async fn test_error_handling_500() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/payment-methods"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": "Internal server error"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_account_payment_methods().await;
+
+    assert!(result.is_err());
+    match result {
+        Err(redis_cloud::CloudError::InternalServerError { .. }) => {}
+        _ => panic!("Expected InternalServerError error"),
+    }
+}
+
+#[tokio::test]
+async fn test_current_account_with_extra_fields() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "https://api.redislabs.com/v1/",
+                    "type": "GET"
+                }
+            ],
+            "accountId": 12345,
+            "accountName": "Test Account",
+            "customField": "custom value"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_current_account().await.unwrap();
+
+    assert!(result.links.is_some());
+    // Test that extra fields are captured in the flattened extra field
+    assert!(result.extra.get("accountId").is_some());
+    assert!(result.extra.get("accountName").is_some());
+    assert!(result.extra.get("customField").is_some());
+
+    if let Some(account_id) = result.extra.get("accountId") {
+        assert_eq!(account_id.as_i64().unwrap(), 12345);
+    }
+
+    if let Some(account_name) = result.extra.get("accountName") {
+        assert_eq!(account_name.as_str().unwrap(), "Test Account");
     }
 }

--- a/crates/redis-cloud/tests/acl_tests.rs
+++ b/crates/redis-cloud/tests/acl_tests.rs
@@ -214,6 +214,535 @@ async fn test_get_user_by_id() {
 }
 
 #[tokio::test]
+async fn test_update_redis_rule() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/acl/redisRules/123"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-update-123",
+            "commandType": "UPDATE_REDIS_RULE",
+            "status": "processing",
+            "description": "Updating Redis ACL rule",
+            "timestamp": "2024-01-01T12:00:00Z"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclRedisRuleUpdateRequest {
+        redis_rule_id: Some(123),
+        name: "updated-rule".to_string(),
+        redis_rule: "+get +set +del".to_string(),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.update_redis_rule(123, &request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-update-123".to_string()));
+    assert_eq!(result.command_type, Some("UPDATE_REDIS_RULE".to_string()));
+    assert_eq!(result.status, Some("processing".to_string()));
+}
+
+#[tokio::test]
+async fn test_create_role() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/acl/roles"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-create-role-789",
+            "commandType": "CREATE_ROLE",
+            "status": "processing",
+            "description": "Creating ACL role",
+            "timestamp": "2024-01-01T13:00:00Z",
+            "response": {
+                "resourceId": 789
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclRoleCreateRequest {
+        name: "test-role".to_string(),
+        redis_rules: vec![redis_cloud::acl::AclRoleRedisRuleSpec {
+            rule_name: "test-rule".to_string(),
+            databases: vec![redis_cloud::acl::AclRoleDatabaseSpec {
+                subscription_id: 100,
+                database_id: 200,
+                regions: Some(vec!["us-east-1".to_string()]),
+                extra: serde_json::Value::Null,
+            }],
+            extra: serde_json::Value::Null,
+        }],
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.create_role(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-create-role-789".to_string()));
+    assert_eq!(result.command_type, Some("CREATE_ROLE".to_string()));
+    assert_eq!(result.status, Some("processing".to_string()));
+}
+
+#[tokio::test]
+async fn test_delete_acl_role() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/acl/roles/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-delete-role-456",
+            "commandType": "DELETE_ROLE",
+            "status": "processing",
+            "description": "Deleting ACL role"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let result = handler.delete_acl_role(456).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-delete-role-456".to_string()));
+    assert_eq!(result.command_type, Some("DELETE_ROLE".to_string()));
+    assert_eq!(result.status, Some("processing".to_string()));
+}
+
+#[tokio::test]
+async fn test_update_role() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/acl/roles/789"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-update-role-789",
+            "commandType": "UPDATE_ROLE",
+            "status": "processing",
+            "description": "Updating ACL role"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclRoleUpdateRequest {
+        name: Some("updated-role-name".to_string()),
+        redis_rules: Some(vec![redis_cloud::acl::AclRoleRedisRuleSpec {
+            rule_name: "updated-rule".to_string(),
+            databases: vec![redis_cloud::acl::AclRoleDatabaseSpec {
+                subscription_id: 101,
+                database_id: 201,
+                regions: None,
+                extra: serde_json::Value::Null,
+            }],
+            extra: serde_json::Value::Null,
+        }]),
+        role_id: Some(789),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.update_role(789, &request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-update-role-789".to_string()));
+    assert_eq!(result.command_type, Some("UPDATE_ROLE".to_string()));
+}
+
+#[tokio::test]
+async fn test_get_all_users() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/users"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 123,
+            "links": [
+                {
+                    "href": "https://api.redislabs.com/v1/acl/users/1",
+                    "type": "GET",
+                    "rel": "user"
+                },
+                {
+                    "href": "https://api.redislabs.com/v1/acl/users/2",
+                    "type": "GET",
+                    "rel": "user"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let result = handler.get_all_users_1().await.unwrap();
+
+    assert_eq!(result.account_id, Some(123));
+    assert!(result.links.is_some());
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 2);
+}
+
+#[tokio::test]
+async fn test_delete_user() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/acl/users/789"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-delete-user-789",
+            "commandType": "DELETE_USER",
+            "status": "processing",
+            "description": "Deleting ACL user"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let result = handler.delete_user(789).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-delete-user-789".to_string()));
+    assert_eq!(result.command_type, Some("DELETE_USER".to_string()));
+    assert_eq!(result.status, Some("processing".to_string()));
+}
+
+#[tokio::test]
+async fn test_update_user() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/acl/users/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-update-user-456",
+            "commandType": "UPDATE_USER",
+            "status": "processing",
+            "description": "Updating ACL user",
+            "timestamp": "2024-01-01T14:00:00Z"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclUserUpdateRequest {
+        user_id: Some(456),
+        role: Some("updated-role".to_string()),
+        password: Some("new-password".to_string()),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.update_user_1(456, &request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-update-user-456".to_string()));
+    assert_eq!(result.command_type, Some("UPDATE_USER".to_string()));
+    assert_eq!(result.status, Some("processing".to_string()));
+}
+
+#[tokio::test]
+async fn test_get_user_by_id_with_links() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/users/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 456,
+            "name": "test-user",
+            "role": "test-role",
+            "status": "active",
+            "links": [
+                {
+                    "href": "https://api.redislabs.com/v1/acl/users/456",
+                    "type": "GET",
+                    "rel": "self"
+                },
+                {
+                    "href": "https://api.redislabs.com/v1/acl/users/456",
+                    "type": "PUT",
+                    "rel": "update"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let result = handler.get_user_by_id(456).await.unwrap();
+
+    assert_eq!(result.id, Some(456));
+    assert_eq!(result.name, Some("test-user".to_string()));
+    assert_eq!(result.role, Some("test-role".to_string()));
+    assert_eq!(result.status, Some("active".to_string()));
+    assert!(result.links.is_some());
+
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 2);
+}
+
+#[tokio::test]
+async fn test_create_role_without_regions() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/acl/roles"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-create-role-simple",
+            "commandType": "CREATE_ROLE",
+            "status": "processing",
+            "description": "Creating ACL role without regions"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclRoleCreateRequest {
+        name: "simple-role".to_string(),
+        redis_rules: vec![redis_cloud::acl::AclRoleRedisRuleSpec {
+            rule_name: "basic-rule".to_string(),
+            databases: vec![redis_cloud::acl::AclRoleDatabaseSpec {
+                subscription_id: 300,
+                database_id: 400,
+                regions: None,
+                extra: serde_json::Value::Null,
+            }],
+            extra: serde_json::Value::Null,
+        }],
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.create_role(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-create-role-simple".to_string()));
+    assert_eq!(
+        result.description,
+        Some("Creating ACL role without regions".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_get_all_redis_rules_empty() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/redisRules"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 123,
+            "links": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let result = handler.get_all_redis_rules().await.unwrap();
+
+    assert_eq!(result.account_id, Some(123));
+    assert!(result.links.is_some());
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 0);
+}
+
+#[tokio::test]
+async fn test_get_roles_empty() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/roles"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 456,
+            "links": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let result = handler.get_roles().await.unwrap();
+
+    assert_eq!(result.account_id, Some(456));
+    assert!(result.links.is_some());
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 0);
+}
+
+#[tokio::test]
+async fn test_task_state_update_with_error() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/acl/redisRules"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-error-123",
+            "commandType": "CREATE_REDIS_RULE",
+            "status": "failed",
+            "description": "Failed to create Redis ACL rule",
+            "timestamp": "2024-01-01T15:00:00Z",
+            "response": {
+                "error": "Invalid rule pattern",
+                "additionalInfo": "Rule pattern '+invalid' is not valid"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclRedisRuleCreateRequest {
+        name: "invalid-rule".to_string(),
+        redis_rule: "+invalid".to_string(),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.create_redis_rule(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-error-123".to_string()));
+    assert_eq!(result.status, Some("failed".to_string()));
+    assert_eq!(
+        result.description,
+        Some("Failed to create Redis ACL rule".to_string())
+    );
+    assert!(result.response.is_some());
+
+    let response = result.response.unwrap();
+    assert_eq!(response.error, Some("Invalid rule pattern".to_string()));
+    assert_eq!(
+        response.additional_info,
+        Some("Rule pattern '+invalid' is not valid".to_string())
+    );
+}
+
+// Error handling tests
+
+#[tokio::test]
+async fn test_error_handling_401() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/roles"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": "Invalid API credentials"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("wrong-key".to_string())
+        .api_secret("wrong-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let result = handler.get_roles().await;
+
+    assert!(result.is_err());
+    match result {
+        Err(redis_cloud::CloudError::AuthenticationFailed { .. }) => {}
+        _ => panic!("Expected AuthenticationFailed error"),
+    }
+}
+
+#[tokio::test]
 async fn test_error_handling_404() {
     let mock_server = MockServer::start().await;
 
@@ -243,4 +772,107 @@ async fn test_error_handling_404() {
     } else {
         panic!("Expected NotFound error");
     }
+}
+
+#[tokio::test]
+async fn test_error_handling_500() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/acl/users"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": "Internal server error"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclUserCreateRequest {
+        name: "test-user".to_string(),
+        role: "test-role".to_string(),
+        password: "test-password".to_string(),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.create_user(&request).await;
+
+    assert!(result.is_err());
+    match result {
+        Err(redis_cloud::CloudError::InternalServerError { .. }) => {}
+        _ => panic!("Expected InternalServerError error"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_user_with_extra_fields() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/acl/users"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-789",
+            "commandType": "CREATE_USER",
+            "status": "processing",
+            "description": "Creating ACL user",
+            "timestamp": "2024-01-01T16:00:00Z",
+            "response": {
+                "resourceId": 999,
+                "additionalResourceId": 888
+            },
+            "customField": "custom value",
+            "links": [
+                {
+                    "href": "https://api.redislabs.com/v1/tasks/task-789",
+                    "type": "GET",
+                    "rel": "task"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AclHandler::new(client);
+    let request = redis_cloud::acl::AclUserCreateRequest {
+        name: "test-user".to_string(),
+        role: "test-role".to_string(),
+        password: "test-password".to_string(),
+        command_type: Some("CREATE_USER".to_string()),
+        extra: json!({
+            "metadata": "user metadata",
+            "customFlag": true
+        }),
+    };
+
+    let result = handler.create_user(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-789".to_string()));
+    assert_eq!(result.command_type, Some("CREATE_USER".to_string()));
+    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.timestamp, Some("2024-01-01T16:00:00Z".to_string()));
+
+    // Test that extra fields are captured
+    assert!(result.extra.get("customField").is_some());
+    assert!(result.links.is_some());
+
+    let response = result.response.unwrap();
+    assert_eq!(response.resource_id, Some(999));
+    assert_eq!(response.additional_resource_id, Some(888));
 }

--- a/crates/redis-cloud/tests/cloud_accounts_tests.rs
+++ b/crates/redis-cloud/tests/cloud_accounts_tests.rs
@@ -210,6 +210,529 @@ async fn test_delete_cloud_account() {
 }
 
 #[tokio::test]
+async fn test_create_cloud_account_without_provider() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/cloud-accounts"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-default-provider",
+            "commandType": "CREATE_CLOUD_ACCOUNT",
+            "status": "processing",
+            "description": "Creating cloud account with default provider (AWS)"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let request = redis_cloud::cloud_accounts::CloudAccountCreateRequest {
+        name: "Default Provider Account".to_string(),
+        provider: None, // Should default to AWS
+        access_key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+        access_secret_key: "secret-key".to_string(),
+        console_username: "admin".to_string(),
+        console_password: "password".to_string(),
+        sign_in_login_url: "https://console.aws.amazon.com".to_string(),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.create_cloud_account(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-default-provider".to_string()));
+    assert_eq!(
+        result.description,
+        Some("Creating cloud account with default provider (AWS)".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_create_gcp_cloud_account() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/cloud-accounts"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-gcp-123",
+            "commandType": "CREATE_CLOUD_ACCOUNT",
+            "status": "processing",
+            "description": "Creating GCP cloud account",
+            "timestamp": "2024-01-02T10:00:00Z",
+            "response": {
+                "resourceId": 890,
+                "additionalInfo": "GCP account validation in progress"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let request = redis_cloud::cloud_accounts::CloudAccountCreateRequest {
+        name: "GCP Cloud Account".to_string(),
+        provider: Some("GCP".to_string()),
+        access_key_id: "gcp-key-id".to_string(),
+        access_secret_key: "gcp-secret-key".to_string(),
+        console_username: "gcp-admin".to_string(),
+        console_password: "gcp-password".to_string(),
+        sign_in_login_url: "https://console.cloud.google.com".to_string(),
+        command_type: Some("CREATE_CLOUD_ACCOUNT".to_string()),
+        extra: json!({
+            "project_id": "my-gcp-project"
+        }),
+    };
+
+    let result = handler.create_cloud_account(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-gcp-123".to_string()));
+    assert_eq!(
+        result.command_type,
+        Some("CREATE_CLOUD_ACCOUNT".to_string())
+    );
+    assert_eq!(result.status, Some("processing".to_string()));
+    assert!(result.response.is_some());
+
+    let response = result.response.unwrap();
+    assert_eq!(response.resource_id, Some(890));
+    assert_eq!(
+        response.additional_info,
+        Some("GCP account validation in progress".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_create_azure_cloud_account() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/cloud-accounts"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-azure-456",
+            "commandType": "CREATE_CLOUD_ACCOUNT",
+            "status": "processing",
+            "description": "Creating Azure cloud account"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let request = redis_cloud::cloud_accounts::CloudAccountCreateRequest {
+        name: "Azure Cloud Account".to_string(),
+        provider: Some("Azure".to_string()),
+        access_key_id: "azure-client-id".to_string(),
+        access_secret_key: "azure-client-secret".to_string(),
+        console_username: "azure-admin".to_string(),
+        console_password: "azure-password".to_string(),
+        sign_in_login_url: "https://portal.azure.com".to_string(),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.create_cloud_account(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-azure-456".to_string()));
+    assert_eq!(
+        result.command_type,
+        Some("CREATE_CLOUD_ACCOUNT".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_get_cloud_accounts_empty() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/cloud-accounts"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 123,
+            "links": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let result = handler.get_cloud_accounts().await.unwrap();
+
+    assert_eq!(result.account_id, Some(123));
+    assert!(result.links.is_some());
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 0);
+}
+
+#[tokio::test]
+async fn test_get_cloud_accounts_multiple() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/cloud-accounts"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 123,
+            "links": [
+                {
+                    "href": "https://api.redislabs.com/v1/cloud-accounts/1",
+                    "type": "GET",
+                    "rel": "cloud-account",
+                    "title": "AWS Production"
+                },
+                {
+                    "href": "https://api.redislabs.com/v1/cloud-accounts/2",
+                    "type": "GET",
+                    "rel": "cloud-account",
+                    "title": "GCP Development"
+                },
+                {
+                    "href": "https://api.redislabs.com/v1/cloud-accounts/3",
+                    "type": "GET",
+                    "rel": "cloud-account",
+                    "title": "Azure Testing"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let result = handler.get_cloud_accounts().await.unwrap();
+
+    assert_eq!(result.account_id, Some(123));
+    assert!(result.links.is_some());
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 3);
+}
+
+#[tokio::test]
+async fn test_get_cloud_account_by_id_gcp() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/cloud-accounts/789"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 789,
+            "name": "GCP Development Account",
+            "status": "active",
+            "accessKeyId": "gcp-service-account-email",
+            "signInLoginUrl": "https://console.cloud.google.com",
+            "provider": "GCP",
+            "links": [
+                {
+                    "href": "https://api.redislabs.com/v1/cloud-accounts/789",
+                    "type": "GET",
+                    "rel": "self"
+                },
+                {
+                    "href": "https://api.redislabs.com/v1/cloud-accounts/789",
+                    "type": "PUT",
+                    "rel": "update"
+                },
+                {
+                    "href": "https://api.redislabs.com/v1/cloud-accounts/789",
+                    "type": "DELETE",
+                    "rel": "delete"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let result = handler.get_cloud_account_by_id(789).await.unwrap();
+
+    assert_eq!(result.id, Some(789));
+    assert_eq!(result.name, Some("GCP Development Account".to_string()));
+    assert_eq!(result.status, Some("active".to_string()));
+    assert_eq!(result.provider, Some("GCP".to_string()));
+    assert_eq!(
+        result.access_key_id,
+        Some("gcp-service-account-email".to_string())
+    );
+    assert_eq!(
+        result.sign_in_login_url,
+        Some("https://console.cloud.google.com".to_string())
+    );
+    assert!(result.links.is_some());
+
+    let links = result.links.unwrap();
+    assert_eq!(links.len(), 3);
+}
+
+#[tokio::test]
+async fn test_get_cloud_account_by_id_with_extra_fields() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/cloud-accounts/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 456,
+            "name": "Test Cloud Account",
+            "status": "active",
+            "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+            "signInLoginUrl": "https://console.aws.amazon.com",
+            "provider": "AWS",
+            "region": "us-west-2",
+            "accountNumber": "123456789012",
+            "roleName": "RedisLabsRole",
+            "externalId": "external-123",
+            "customMetadata": {
+                "environment": "production",
+                "team": "platform"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let result = handler.get_cloud_account_by_id(456).await.unwrap();
+
+    assert_eq!(result.id, Some(456));
+    assert_eq!(result.name, Some("Test Cloud Account".to_string()));
+    assert_eq!(result.status, Some("active".to_string()));
+    assert_eq!(result.provider, Some("AWS".to_string()));
+
+    // Test that extra fields are captured
+    assert!(result.extra.get("region").is_some());
+    assert!(result.extra.get("accountNumber").is_some());
+    assert!(result.extra.get("roleName").is_some());
+    assert!(result.extra.get("customMetadata").is_some());
+
+    if let Some(region) = result.extra.get("region") {
+        assert_eq!(region.as_str().unwrap(), "us-west-2");
+    }
+
+    if let Some(account_number) = result.extra.get("accountNumber") {
+        assert_eq!(account_number.as_str().unwrap(), "123456789012");
+    }
+}
+
+#[tokio::test]
+async fn test_update_cloud_account_minimal() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/cloud-accounts/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-minimal-update",
+            "commandType": "UPDATE_CLOUD_ACCOUNT",
+            "status": "processing",
+            "description": "Updating cloud account credentials only"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let request = redis_cloud::cloud_accounts::CloudAccountUpdateRequest {
+        name: None, // Not updating name
+        cloud_account_id: Some(456),
+        access_key_id: "NEW-ACCESS-KEY".to_string(),
+        access_secret_key: "new-secret-key".to_string(),
+        console_username: "updated-admin".to_string(),
+        console_password: "updated-password".to_string(),
+        sign_in_login_url: None, // Not updating URL
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.update_cloud_account(456, &request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-minimal-update".to_string()));
+    assert_eq!(
+        result.command_type,
+        Some("UPDATE_CLOUD_ACCOUNT".to_string())
+    );
+    assert_eq!(
+        result.description,
+        Some("Updating cloud account credentials only".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_task_state_update_with_failed_status() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/cloud-accounts"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-failed-123",
+            "commandType": "CREATE_CLOUD_ACCOUNT",
+            "status": "failed",
+            "description": "Failed to create cloud account",
+            "timestamp": "2024-01-01T15:00:00Z",
+            "response": {
+                "error": "Invalid credentials",
+                "additionalInfo": "Access key validation failed"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let request = redis_cloud::cloud_accounts::CloudAccountCreateRequest {
+        name: "Failed Account".to_string(),
+        provider: Some("AWS".to_string()),
+        access_key_id: "INVALID-KEY".to_string(),
+        access_secret_key: "invalid-secret".to_string(),
+        console_username: "admin".to_string(),
+        console_password: "password".to_string(),
+        sign_in_login_url: "https://console.aws.amazon.com".to_string(),
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.create_cloud_account(&request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-failed-123".to_string()));
+    assert_eq!(result.status, Some("failed".to_string()));
+    assert_eq!(
+        result.description,
+        Some("Failed to create cloud account".to_string())
+    );
+    assert!(result.response.is_some());
+
+    let response = result.response.unwrap();
+    assert_eq!(response.error, Some("Invalid credentials".to_string()));
+    assert_eq!(
+        response.additional_info,
+        Some("Access key validation failed".to_string())
+    );
+}
+
+// Error handling tests
+
+#[tokio::test]
+async fn test_error_handling_401() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/cloud-accounts"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": "Invalid API credentials"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("wrong-key".to_string())
+        .api_secret("wrong-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let result = handler.get_cloud_accounts().await;
+
+    assert!(result.is_err());
+    match result {
+        Err(redis_cloud::CloudError::AuthenticationFailed { .. }) => {}
+        _ => panic!("Expected AuthenticationFailed error"),
+    }
+}
+
+#[tokio::test]
+async fn test_error_handling_403() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/cloud-accounts/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+            "error": "Forbidden: Cannot delete cloud account with active subscriptions"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let result = handler.delete_cloud_account(456).await;
+
+    assert!(result.is_err());
+    match result {
+        Err(redis_cloud::CloudError::Forbidden { .. }) => {}
+        _ => panic!("Expected Forbidden error"),
+    }
+}
+
+#[tokio::test]
 async fn test_error_handling_404() {
     let mock_server = MockServer::start().await;
 
@@ -238,5 +761,48 @@ async fn test_error_handling_404() {
         assert!(message.contains("not found") || message.contains("404"));
     } else {
         panic!("Expected NotFound error");
+    }
+}
+
+#[tokio::test]
+async fn test_error_handling_500() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/cloud-accounts/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": "Internal server error"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = CloudAccountHandler::new(client);
+    let request = redis_cloud::cloud_accounts::CloudAccountUpdateRequest {
+        name: Some("Updated Account".to_string()),
+        cloud_account_id: None,
+        access_key_id: "ACCESS-KEY".to_string(),
+        access_secret_key: "secret-key".to_string(),
+        console_username: "admin".to_string(),
+        console_password: "password".to_string(),
+        sign_in_login_url: None,
+        command_type: None,
+        extra: serde_json::Value::Null,
+    };
+
+    let result = handler.update_cloud_account(456, &request).await;
+
+    assert!(result.is_err());
+    match result {
+        Err(redis_cloud::CloudError::InternalServerError { .. }) => {}
+        _ => panic!("Expected InternalServerError error"),
     }
 }


### PR DESCRIPTION
## Summary
- Enhanced test coverage for account, ACL, and cloud accounts handlers in the redis-cloud crate
- Added 57 comprehensive tests that follow the OpenAPI spec exactly
- All tests pass successfully

## Test Coverage Details

### Account Handler (17 tests)
- ✅ All 8 methods covered
- ✅ Edge cases: Optional parameters, empty responses, different providers  
- ✅ Error handling: 401, 404, 500 HTTP errors
- ✅ Forward compatibility with extra fields

### ACL Handler (22 tests)
- ✅ All 11 methods covered
- ✅ Complex request structures with roles, rules, and users
- ✅ Task state handling for async operations
- ✅ Comprehensive error handling

### Cloud Accounts Handler (18 tests)
- ✅ All 5 methods covered
- ✅ Multi-cloud support: AWS, GCP, Azure
- ✅ Request variations and response scenarios
- ✅ Error handling including 403 forbidden

## Test Results
```
Running tests/account_tests.rs: 17 passed
Running tests/acl_tests.rs: 22 passed  
Running tests/cloud_accounts_tests.rs: 18 passed
```

All 57 tests pass successfully.