### PR TITLE
test: add comprehensive tests for remaining Enterprise handlers

### DIFF
--- a/crates/redis-enterprise/tests/bdb_groups_tests.rs
+++ b/crates/redis-enterprise/tests/bdb_groups_tests.rs
@@ -1,0 +1,187 @@
+#[cfg(test)]
+mod tests {
+    use redis_enterprise::EnterpriseClient;
+    use redis_enterprise::bdb_groups::{
+        BdbGroupsHandler, CreateBdbGroupRequest, UpdateBdbGroupRequest,
+    };
+    use serde_json::json;
+    use wiremock::matchers::{basic_auth, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn setup_mock_client(mock_server: &MockServer) -> BdbGroupsHandler {
+        let client = EnterpriseClient::builder()
+            .base_url(mock_server.uri())
+            .username("test_user")
+            .password("test_pass")
+            .build()
+            .unwrap();
+        BdbGroupsHandler::new(client)
+    }
+
+    #[tokio::test]
+    async fn test_list_bdb_groups() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!([
+            {
+                "uid": 1,
+                "name": "group1",
+                "bdbs": [1, 2, 3]
+            },
+            {
+                "uid": 2,
+                "name": "group2",
+                "bdbs": [4, 5]
+            }
+        ]);
+
+        Mock::given(method("GET"))
+            .and(path("/v1/bdb_groups"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let groups = handler.list().await.unwrap();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].uid, 1);
+        assert_eq!(groups[0].name, "group1");
+        assert_eq!(groups[1].uid, 2);
+        assert_eq!(groups[1].name, "group2");
+    }
+
+    #[tokio::test]
+    async fn test_get_bdb_group() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "uid": 1,
+            "name": "test_group",
+            "bdbs": [1, 2, 3],
+            "sync": "enabled"
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/bdb_groups/1"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let group = handler.get(1).await.unwrap();
+        assert_eq!(group.uid, 1);
+        assert_eq!(group.name, "test_group");
+    }
+
+    #[tokio::test]
+    async fn test_create_bdb_group() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request = CreateBdbGroupRequest {
+            name: "new_group".to_string(),
+        };
+
+        let response_body = json!({
+            "uid": 3,
+            "name": "new_group",
+            "bdbs": []
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/bdb_groups"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let group = handler.create(request).await.unwrap();
+        assert_eq!(group.uid, 3);
+        assert_eq!(group.name, "new_group");
+    }
+
+    #[tokio::test]
+    async fn test_update_bdb_group() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request = UpdateBdbGroupRequest {
+            name: Some("updated_group".to_string()),
+        };
+
+        let response_body = json!({
+            "uid": 1,
+            "name": "updated_group",
+            "bdbs": [1, 2, 3]
+        });
+
+        Mock::given(method("PUT"))
+            .and(path("/v1/bdb_groups/1"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let group = handler.update(1, request).await.unwrap();
+        assert_eq!(group.uid, 1);
+        assert_eq!(group.name, "updated_group");
+    }
+
+    #[tokio::test]
+    async fn test_delete_bdb_group() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/v1/bdb_groups/1"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.delete(1).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_bdb_group_not_found() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/bdb_groups/999"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "error": "BDB group not found"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.get(999).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_bdb_group_with_invalid_name() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request = CreateBdbGroupRequest {
+            name: "".to_string(),
+        };
+
+        Mock::given(method("POST"))
+            .and(path("/v1/bdb_groups"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "Invalid group name"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.create(request).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/redis-enterprise/tests/debuginfo_tests.rs
+++ b/crates/redis-enterprise/tests/debuginfo_tests.rs
@@ -1,0 +1,263 @@
+#[cfg(test)]
+mod tests {
+    use redis_enterprise::EnterpriseClient;
+    use redis_enterprise::debuginfo::{DebugInfoHandler, DebugInfoRequest, TimeRange};
+    use serde_json::json;
+    use wiremock::matchers::{basic_auth, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn setup_mock_client(mock_server: &MockServer) -> DebugInfoHandler {
+        let client = EnterpriseClient::builder()
+            .base_url(mock_server.uri())
+            .username("test_user")
+            .password("test_pass")
+            .build()
+            .unwrap();
+        DebugInfoHandler::new(client)
+    }
+
+    #[tokio::test]
+    async fn test_create_debug_info() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request = DebugInfoRequest::builder()
+            .node_uids(vec![1, 2])
+            .include_logs(true)
+            .include_metrics(true)
+            .build();
+
+        let response_body = json!({
+            "task_id": "debug-task-123",
+            "status": "in_progress",
+            "progress": 0.0
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/debuginfo"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let status = handler.create(request).await.unwrap();
+        assert_eq!(status.task_id, "debug-task-123");
+        assert_eq!(status.status, "in_progress");
+    }
+
+    #[tokio::test]
+    async fn test_get_debug_info_status() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "task_id": "debug-task-123",
+            "status": "completed",
+            "progress": 100.0,
+            "download_url": "/v1/debuginfo/debug-task-123/download"
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/debuginfo/debug-task-123"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let status = handler.status("debug-task-123").await.unwrap();
+        assert_eq!(status.task_id, "debug-task-123");
+        assert_eq!(status.status, "completed");
+        assert_eq!(status.progress, Some(100.0));
+        assert!(status.download_url.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_list_debug_info_tasks() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!([
+            {
+                "task_id": "debug-task-123",
+                "status": "completed",
+                "progress": 100.0
+            },
+            {
+                "task_id": "debug-task-456",
+                "status": "in_progress",
+                "progress": 45.0
+            }
+        ]);
+
+        Mock::given(method("GET"))
+            .and(path("/v1/debuginfo"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let tasks = handler.list().await.unwrap();
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0].task_id, "debug-task-123");
+        assert_eq!(tasks[1].task_id, "debug-task-456");
+    }
+
+    // TODO: This test is commented out because the client doesn't support binary responses yet
+    // The download method returns Vec<u8> but the client always tries to parse as JSON
+    #[ignore = "Client doesn't support binary responses yet"]
+    #[tokio::test]
+    async fn test_download_debug_info() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = b"debug package binary content";
+
+        Mock::given(method("GET"))
+            .and(path("/v1/debuginfo/debug-task-123/download"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(response_body.to_vec(), "application/octet-stream"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // This will fail because client tries to parse binary as JSON
+        let _result = handler.download("debug-task-123").await;
+        // assert_eq!(data, response_body);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_debug_info() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/v1/debuginfo/debug-task-123"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.cancel("debug-task-123").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_all_debug_info() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "nodes": [
+                {"node_uid": 1, "debug_data": "node1 info"},
+                {"node_uid": 2, "debug_data": "node2 info"}
+            ]
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/debuginfo/all"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.all().await.unwrap();
+        assert!(result.get("nodes").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_all_bdb_debug_info() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "bdb_uid": 1,
+            "debug_data": "database debug info"
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/debuginfo/all/bdb/1"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.all_bdb(1).await.unwrap();
+        assert_eq!(result["bdb_uid"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_node_debug_info() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "node_uid": 1,
+            "status": "healthy",
+            "debug_data": "local node debug info"
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/debuginfo/node"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.node().await.unwrap();
+        assert_eq!(result["status"], "healthy");
+    }
+
+    #[tokio::test]
+    async fn test_get_node_bdb_debug_info() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "bdb_uid": 2,
+            "node_uid": 1,
+            "debug_data": "node specific database debug info"
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/debuginfo/node/bdb/2"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.node_bdb(2).await.unwrap();
+        assert_eq!(result["bdb_uid"], 2);
+    }
+
+    #[tokio::test]
+    async fn test_create_debug_info_with_time_range() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request = DebugInfoRequest::builder()
+            .time_range(TimeRange {
+                start: "2024-01-01T00:00:00Z".to_string(),
+                end: "2024-01-02T00:00:00Z".to_string(),
+            })
+            .include_configs(true)
+            .build();
+
+        let response_body = json!({
+            "task_id": "debug-task-789",
+            "status": "queued"
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/debuginfo"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let status = handler.create(request).await.unwrap();
+        assert_eq!(status.task_id, "debug-task-789");
+        assert_eq!(status.status, "queued");
+    }
+}

--- a/crates/redis-enterprise/tests/local_tests.rs
+++ b/crates/redis-enterprise/tests/local_tests.rs
@@ -1,0 +1,278 @@
+#[cfg(test)]
+mod tests {
+    use redis_enterprise::EnterpriseClient;
+    use redis_enterprise::local::LocalHandler;
+    use serde_json::json;
+    use wiremock::matchers::{basic_auth, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn setup_mock_client(mock_server: &MockServer) -> LocalHandler {
+        let client = EnterpriseClient::builder()
+            .base_url(mock_server.uri())
+            .username("test_user")
+            .password("test_pass")
+            .build()
+            .unwrap();
+        LocalHandler::new(client)
+    }
+
+    #[tokio::test]
+    async fn test_master_healthcheck() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "status": "healthy",
+            "node_uid": 1,
+            "role": "master",
+            "uptime": 3600,
+            "services": {
+                "cm_server": "running",
+                "mdns_server": "running",
+                "pdns_server": "running"
+            }
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/local/node/master_healthcheck"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.master_healthcheck().await.unwrap();
+        assert_eq!(result["status"], "healthy");
+        assert_eq!(result["role"], "master");
+        assert_eq!(result["node_uid"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_master_healthcheck_unhealthy() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "status": "unhealthy",
+            "node_uid": 1,
+            "role": "master",
+            "errors": ["Service cm_server is not running"]
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/local/node/master_healthcheck"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(503).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.master_healthcheck().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_services() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "services": [
+                {
+                    "name": "cm_server",
+                    "status": "running",
+                    "port": 8080,
+                    "pid": 1234
+                },
+                {
+                    "name": "mdns_server",
+                    "status": "running",
+                    "port": 53,
+                    "pid": 1235
+                },
+                {
+                    "name": "pdns_server",
+                    "status": "stopped",
+                    "port": 6379,
+                    "pid": null
+                }
+            ]
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/local/services"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.services().await.unwrap();
+        let services = result["services"].as_array().unwrap();
+        assert_eq!(services.len(), 3);
+        assert_eq!(services[0]["name"], "cm_server");
+        assert_eq!(services[0]["status"], "running");
+    }
+
+    #[tokio::test]
+    async fn test_update_services() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request_body = json!({
+            "services": [
+                {
+                    "name": "pdns_server",
+                    "action": "start"
+                }
+            ]
+        });
+
+        let response_body = json!({
+            "status": "success",
+            "services": [
+                {
+                    "name": "pdns_server",
+                    "status": "starting",
+                    "message": "Service start initiated"
+                }
+            ]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/local/services"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.services_update(request_body).await.unwrap();
+        assert_eq!(result["status"], "success");
+        assert_eq!(result["services"][0]["status"], "starting");
+    }
+
+    #[tokio::test]
+    async fn test_update_services_restart() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request_body = json!({
+            "services": [
+                {
+                    "name": "cm_server",
+                    "action": "restart"
+                },
+                {
+                    "name": "mdns_server",
+                    "action": "restart"
+                }
+            ]
+        });
+
+        let response_body = json!({
+            "status": "success",
+            "services": [
+                {
+                    "name": "cm_server",
+                    "status": "restarting"
+                },
+                {
+                    "name": "mdns_server",
+                    "status": "restarting"
+                }
+            ]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/local/services"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.services_update(request_body).await.unwrap();
+        assert_eq!(result["status"], "success");
+        assert_eq!(result["services"][0]["status"], "restarting");
+        assert_eq!(result["services"][1]["status"], "restarting");
+    }
+
+    #[tokio::test]
+    async fn test_update_services_stop() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request_body = json!({
+            "services": [
+                {
+                    "name": "pdns_server",
+                    "action": "stop"
+                }
+            ]
+        });
+
+        let response_body = json!({
+            "status": "success",
+            "services": [
+                {
+                    "name": "pdns_server",
+                    "status": "stopped"
+                }
+            ]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/local/services"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.services_update(request_body).await.unwrap();
+        assert_eq!(result["services"][0]["status"], "stopped");
+    }
+
+    #[tokio::test]
+    async fn test_update_services_invalid_action() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let request_body = json!({
+            "services": [
+                {
+                    "name": "invalid_service",
+                    "action": "invalid_action"
+                }
+            ]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/local/services"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "Invalid service action"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.services_update(request_body).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_services_empty_list() {
+        let mock_server = MockServer::start().await;
+        let handler = setup_mock_client(&mock_server).await;
+
+        let response_body = json!({
+            "services": []
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/local/services"))
+            .and(basic_auth("test_user", "test_pass"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = handler.services().await.unwrap();
+        let services = result["services"].as_array().unwrap();
+        assert_eq!(services.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

This PR completes the test coverage for Redis Enterprise handlers, achieving 100% handler coverage (31/31 handlers tested).

## Changes

### ✅ Added Tests for  Handler (7 tests)
- List all BDB groups
- Get specific BDB group
- Create new BDB group
- Update existing BDB group
- Delete BDB group
- Error handling for not found
- Error handling for invalid group name

### ✅ Added Tests for  Handler (10 tests, 1 ignored)
- Create debug info collection task
- Get task status
- List all debug info tasks
- Download debug package (ignored - client limitation)
- Cancel debug info collection
- Get all debug info across nodes
- Get database-specific debug info
- Get node debug info
- Get node-specific database debug info
- Create with time range filters

**Note:** The binary download test is marked as ignored because the current client implementation doesn't support binary responses (always tries to parse as JSON).

### ✅ Added Tests for  Handler (8 tests)
- Master node health check (healthy)
- Master node health check (unhealthy)
- List local services
- Update services (start)
- Update services (restart multiple)
- Update services (stop)
- Invalid service action error handling
- Empty services list

## Test Results

```
running 7 tests (bdb_groups)
test result: ok. 7 passed; 0 failed; 0 ignored

running 10 tests (debuginfo)
test result: ok. 9 passed; 0 failed; 1 ignored

running 8 tests (local)
test result: ok. 8 passed; 0 failed; 0 ignored
```

## Coverage Impact

- **Before:** 90.3% handler coverage (28/31 handlers tested)
- **After:** 100% handler coverage (31/31 handlers tested) 🎉

## Closes

Closes #107