### PR TITLE
refactor: fix naming inconsistencies and typos

### DIFF
--- a/crates/redis-cloud/src/acl.rs
+++ b/crates/redis-cloud/src/acl.rs
@@ -32,7 +32,7 @@
 //! let handler = AclHandler::new(client);
 //!
 //! // List all ACL users
-//! let users = handler.get_all_users_1().await?;
+//! let users = handler.get_all_acl_users().await?;
 //!
 //! // Get all Redis rules
 //! let rules = handler.get_all_redis_rules().await?;
@@ -443,7 +443,7 @@ impl AclHandler {
     /// Gets a list of all access control users for this account.
     ///
     /// GET /acl/users
-    pub async fn get_all_users_1(&self) -> Result<AccountACLUsers> {
+    pub async fn get_all_acl_users(&self) -> Result<AccountACLUsers> {
         self.client.get("/acl/users").await
     }
 
@@ -481,7 +481,7 @@ impl AclHandler {
     /// Updates a access control user with a different role or database password.
     ///
     /// PUT /acl/users/{aclUserId}
-    pub async fn update_user_1(
+    pub async fn update_acl_user(
         &self,
         acl_user_id: i32,
         request: &AclUserUpdateRequest,

--- a/crates/redis-cloud/src/connectivity.rs
+++ b/crates/redis-cloud/src/connectivity.rs
@@ -957,7 +957,7 @@ impl ConnectivityHandler {
     /// (Active-Active subscriptions only) Gets the gcloud script to create the specified Private Service Connect endpoint on Google Cloud.
     ///
     /// GET /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect/{pscServiceId}/endpoints/{endpointId}/creationScripts
-    pub async fn get_active_activ_psc_service_endpoint_creation_script(
+    pub async fn get_active_active_psc_service_endpoint_creation_script(
         &self,
         subscription_id: i32,
         region_id: i32,
@@ -971,7 +971,7 @@ impl ConnectivityHandler {
     /// (Active-Active subscriptions only) Gets the gcloud script to delete the specified Private Service Connect endpoint on Google Cloud.
     ///
     /// GET /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect/{pscServiceId}/endpoints/{endpointId}/deletionScripts
-    pub async fn get_active_activ_psc_service_endpoint_deletion_script(
+    pub async fn get_active_active_psc_service_endpoint_deletion_script(
         &self,
         subscription_id: i32,
         region_id: i32,

--- a/crates/redis-cloud/src/databases.rs
+++ b/crates/redis-cloud/src/databases.rs
@@ -347,7 +347,7 @@ pub struct CrdbUpdatePropertiesRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_password: Option<String>,
 
-    /// Optional. List of source IP addresses or subnet masks to whitelist in all regions that don't set local 'sourceIp' settings. If set, Redis clients will be able to connect to this database only from within the specified source IP addresses ranges. Example: ['192.168.10.0/32', '192.168.12.0/24']
+    /// Optional. List of source IP addresses or subnet masks to allow in all regions that don't set local 'sourceIp' settings. If set, Redis clients will be able to connect to this database only from within the specified source IP addresses ranges. Example: ['192.168.10.0/32', '192.168.12.0/24']
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_source_ip: Option<Vec<String>>,
 
@@ -787,7 +787,7 @@ pub struct LocalRegionProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
 
-    /// Optional. List of source IP addresses or subnet masks to whitelist in this region. If set, Redis clients will be able to connect to the database in this region only from within the specified source IP addresses ranges, and 'globalSourceIp' will not apply to this region. Example: ['192.168.10.0/32', '192.168.12.0/24']
+    /// Optional. List of source IP addresses or subnet masks to allow in this region. If set, Redis clients will be able to connect to the database in this region only from within the specified source IP addresses ranges, and 'globalSourceIp' will not apply to this region. Example: ['192.168.10.0/32', '192.168.12.0/24']
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ip: Option<Vec<String>>,
 

--- a/crates/redis-cloud/src/fixed_databases.rs
+++ b/crates/redis-cloud/src/fixed_databases.rs
@@ -802,7 +802,7 @@ impl FixedDatabasesHandler {
     /// Deletes a database from an Essentials subscription.
     ///
     /// DELETE /fixed/subscriptions/{subscriptionId}/databases/{databaseId}
-    pub async fn delete_fixed_database_by_id_1(
+    pub async fn delete_fixed_database_by_id(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -821,7 +821,7 @@ impl FixedDatabasesHandler {
     /// Gets details and settings of a single database in an Essentials subscription.
     ///
     /// GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}
-    pub async fn get_subscription_database_by_id_1(
+    pub async fn get_fixed_subscription_database_by_id(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -859,7 +859,7 @@ impl FixedDatabasesHandler {
     /// Information on the latest database backup status identified by Essentials subscription Id and Essentials database Id
     ///
     /// GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/backup
-    pub async fn get_database_backup_status_1(
+    pub async fn get_fixed_database_backup_status(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -876,7 +876,7 @@ impl FixedDatabasesHandler {
     /// Manually back up the specified Essentials database to a backup path. By default, backups will be stored in the 'periodicBackupPath' location for this database.
     ///
     /// POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/backup
-    pub async fn backup_database_1(
+    pub async fn backup_fixed_database(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -897,7 +897,7 @@ impl FixedDatabasesHandler {
     /// Gets information on the latest import attempt for this Essentials database.
     ///
     /// GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/import
-    pub async fn get_database_import_status_1(
+    pub async fn get_fixed_database_import_status(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -914,7 +914,7 @@ impl FixedDatabasesHandler {
     /// Imports data from an RDB file or from a different Redis database into this Essentials database. WARNING: Importing data into a database removes all existing data from the database.
     ///
     /// POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/import
-    pub async fn import_database_1(
+    pub async fn import_fixed_database(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -935,7 +935,7 @@ impl FixedDatabasesHandler {
     /// Get slow-log for a specific database identified by Essentials subscription Id and database Id
     ///
     /// GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/slow-log
-    pub async fn get_slow_log_1(
+    pub async fn get_fixed_database_slow_log(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -952,7 +952,11 @@ impl FixedDatabasesHandler {
     /// Gets a list of all database tags.
     ///
     /// GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags
-    pub async fn get_tags_1(&self, subscription_id: i32, database_id: i32) -> Result<CloudTags> {
+    pub async fn get_fixed_database_tags(
+        &self,
+        subscription_id: i32,
+        database_id: i32,
+    ) -> Result<CloudTags> {
         self.client
             .get(&format!(
                 "/fixed/subscriptions/{}/databases/{}/tags",
@@ -965,7 +969,7 @@ impl FixedDatabasesHandler {
     /// Adds a single database tag to a database.
     ///
     /// POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags
-    pub async fn create_tag_1(
+    pub async fn create_fixed_database_tag(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -986,7 +990,7 @@ impl FixedDatabasesHandler {
     /// Overwrites all tags on the database.
     ///
     /// PUT /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags
-    pub async fn update_tags_1(
+    pub async fn update_fixed_database_tags(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -1007,7 +1011,7 @@ impl FixedDatabasesHandler {
     /// Removes the specified tag from the database.
     ///
     /// DELETE /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}
-    pub async fn delete_tag_1(
+    pub async fn delete_fixed_database_tag(
         &self,
         subscription_id: i32,
         database_id: i32,
@@ -1027,7 +1031,7 @@ impl FixedDatabasesHandler {
     /// Updates the value of the specified database tag.
     ///
     /// PUT /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}
-    pub async fn update_tag_1(
+    pub async fn update_fixed_database_tag(
         &self,
         subscription_id: i32,
         database_id: i32,

--- a/crates/redis-cloud/src/fixed_subscriptions.rs
+++ b/crates/redis-cloud/src/fixed_subscriptions.rs
@@ -44,7 +44,7 @@
 //! let plans = handler.get_all_fixed_subscriptions_plans(None, None).await?;
 //!
 //! // Get all fixed subscriptions
-//! let subscriptions = handler.get_all_subscriptions_1().await?;
+//! let subscriptions = handler.get_all_fixed_subscriptions().await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -479,7 +479,7 @@ impl FixedSubscriptionsHandler {
     /// Gets a list of all available Redis database versions for a specific Essentials subscription.
     ///
     /// GET /fixed/redis-versions
-    pub async fn get_redis_versions_1(&self, subscription_id: i32) -> Result<RedisVersions> {
+    pub async fn get_fixed_redis_versions(&self, subscription_id: i32) -> Result<RedisVersions> {
         let mut query = Vec::new();
         query.push(format!("subscriptionId={}", subscription_id));
         let query_string = if query.is_empty() {
@@ -496,7 +496,7 @@ impl FixedSubscriptionsHandler {
     /// Gets a list of all Essentials subscriptions in the current account.
     ///
     /// GET /fixed/subscriptions
-    pub async fn get_all_subscriptions_1(&self) -> Result<FixedSubscriptions> {
+    pub async fn get_all_fixed_subscriptions(&self) -> Result<FixedSubscriptions> {
         self.client.get("/fixed/subscriptions").await
     }
 
@@ -504,7 +504,7 @@ impl FixedSubscriptionsHandler {
     /// Creates a new Essentials subscription.
     ///
     /// POST /fixed/subscriptions
-    pub async fn create_subscription_1(
+    pub async fn create_fixed_subscription(
         &self,
         request: &FixedSubscriptionCreateRequest,
     ) -> Result<TaskStateUpdate> {
@@ -515,7 +515,7 @@ impl FixedSubscriptionsHandler {
     /// Deletes the specified Essentials subscription. All databases in the subscription must be deleted before deleting it.
     ///
     /// DELETE /fixed/subscriptions/{subscriptionId}
-    pub async fn delete_subscription_by_id_1(
+    pub async fn delete_fixed_subscription_by_id(
         &self,
         subscription_id: i32,
     ) -> Result<TaskStateUpdate> {
@@ -530,7 +530,7 @@ impl FixedSubscriptionsHandler {
     /// Gets information on the specified Essentials subscription.
     ///
     /// GET /fixed/subscriptions/{subscriptionId}
-    pub async fn get_subscription_by_id_1(
+    pub async fn get_fixed_subscription_by_id(
         &self,
         subscription_id: i32,
     ) -> Result<FixedSubscription> {
@@ -543,7 +543,7 @@ impl FixedSubscriptionsHandler {
     /// Updates the specified Essentials subscription.
     ///
     /// PUT /fixed/subscriptions/{subscriptionId}
-    pub async fn update_subscription_1(
+    pub async fn update_fixed_subscription(
         &self,
         subscription_id: i32,
         request: &FixedSubscriptionUpdateRequest,

--- a/crates/redis-cloud/src/subscriptions.rs
+++ b/crates/redis-cloud/src/subscriptions.rs
@@ -17,7 +17,7 @@
 //! - **Active-Active**: Global database replication with local reads/writes
 //! - **Advanced Networking**: VPC peering, Transit Gateway, Private endpoints
 //! - **Maintenance Windows**: Configurable maintenance scheduling
-//! - **CIDR Management**: IP whitelist and security group configuration
+//! - **CIDR Management**: IP allowlist and security group configuration
 //! - **Custom Pricing**: Usage-based pricing with detailed cost tracking
 //!
 //! # Subscription Types
@@ -240,7 +240,7 @@ pub struct DatabaseModuleSpec {
 /// Update Pro subscription
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CidrWhiteListUpdateRequest {
+pub struct CidrAllowlistUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
@@ -910,24 +910,24 @@ impl SubscriptionsHandler {
             .await
     }
 
-    /// Get Pro subscription CIDR whitelist
-    /// (Self-hosted AWS subscriptions only) Gets a Pro subscription's CIDR whitelist.
+    /// Get Pro subscription CIDR allowlist
+    /// (Self-hosted AWS subscriptions only) Gets a Pro subscription's CIDR allowlist.
     ///
     /// GET /subscriptions/{subscriptionId}/cidr
-    pub async fn get_cidr_white_list(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
+    pub async fn get_cidr_allowlist(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!("/subscriptions/{}/cidr", subscription_id))
             .await
     }
 
-    /// Update Pro subscription CIDR whitelist
-    /// (Self-hosted AWS subscriptions only) Updates a Pro subscription's CIDR whitelist.
+    /// Update Pro subscription CIDR allowlist
+    /// (Self-hosted AWS subscriptions only) Updates a Pro subscription's CIDR allowlist.
     ///
     /// PUT /subscriptions/{subscriptionId}/cidr
-    pub async fn update_subscription_cidr_white_list(
+    pub async fn update_subscription_cidr_allowlist(
         &self,
         subscription_id: i32,
-        request: &CidrWhiteListUpdateRequest,
+        request: &CidrAllowlistUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(&format!("/subscriptions/{}/cidr", subscription_id), request)

--- a/crates/redis-cloud/tests/acl_tests.rs
+++ b/crates/redis-cloud/tests/acl_tests.rs
@@ -417,7 +417,7 @@ async fn test_get_all_users() {
         .unwrap();
 
     let handler = AclHandler::new(client);
-    let result = handler.get_all_users_1().await.unwrap();
+    let result = handler.get_all_acl_users().await.unwrap();
 
     assert_eq!(result.account_id, Some(123));
     assert!(result.links.is_some());
@@ -491,7 +491,7 @@ async fn test_update_user() {
         extra: serde_json::Value::Null,
     };
 
-    let result = handler.update_user_1(456, &request).await.unwrap();
+    let result = handler.update_acl_user(456, &request).await.unwrap();
     assert_eq!(result.task_id, Some("task-update-user-456".to_string()));
     assert_eq!(result.command_type, Some("UPDATE_USER".to_string()));
     assert_eq!(result.status, Some("processing".to_string()));

--- a/crates/redis-cloud/tests/fixed_databases_tests.rs
+++ b/crates/redis-cloud/tests/fixed_databases_tests.rs
@@ -199,10 +199,7 @@ async fn test_delete_fixed_database() {
         .unwrap();
 
     let handler = FixedDatabaseHandler::new(client);
-    let result = handler
-        .delete_fixed_database_by_id_1(123, 456)
-        .await
-        .unwrap();
+    let result = handler.delete_fixed_database_by_id(123, 456).await.unwrap();
 
     assert_eq!(result.task_id, Some("task-delete-fixed-db".to_string()));
     assert_eq!(
@@ -242,7 +239,10 @@ async fn test_backup_fixed_database() {
         command_type: None,
         extra: serde_json::Value::Null,
     };
-    let result = handler.backup_database_1(123, 456, &request).await.unwrap();
+    let result = handler
+        .backup_fixed_database(123, 456, &request)
+        .await
+        .unwrap();
 
     assert_eq!(result.task_id, Some("task-backup-fixed-db".to_string()));
 }
@@ -281,7 +281,10 @@ async fn test_import_fixed_database() {
         extra: serde_json::Value::Null,
     };
 
-    let result = handler.import_database_1(123, 456, &request).await.unwrap();
+    let result = handler
+        .import_fixed_database(123, 456, &request)
+        .await
+        .unwrap();
     assert_eq!(result.task_id, Some("task-import-fixed-db".to_string()));
 }
 
@@ -318,7 +321,10 @@ async fn test_tag_operations() {
         extra: serde_json::Value::Null,
     };
 
-    let result = handler.create_tag_1(123, 456, &request).await.unwrap();
+    let result = handler
+        .create_fixed_database_tag(123, 456, &request)
+        .await
+        .unwrap();
     assert!(result.key.is_some());
 }
 
@@ -375,7 +381,7 @@ async fn test_error_handling_403() {
         .unwrap();
 
     let handler = FixedDatabaseHandler::new(client);
-    let result = handler.delete_fixed_database_by_id_1(123, 456).await;
+    let result = handler.delete_fixed_database_by_id(123, 456).await;
 
     assert!(result.is_err());
     match result {
@@ -406,7 +412,9 @@ async fn test_error_handling_404() {
         .unwrap();
 
     let handler = FixedDatabaseHandler::new(client);
-    let result = handler.get_subscription_database_by_id_1(999, 999).await;
+    let result = handler
+        .get_fixed_subscription_database_by_id(999, 999)
+        .await;
 
     assert!(result.is_err());
     if let Err(redis_cloud::CloudError::NotFound { message }) = result {

--- a/crates/redis-cloud/tests/fixed_subscriptions_tests.rs
+++ b/crates/redis-cloud/tests/fixed_subscriptions_tests.rs
@@ -168,7 +168,7 @@ async fn test_get_redis_versions() {
         .unwrap();
 
     let handler = FixedSubscriptionsHandler::new(client);
-    let result = handler.get_redis_versions_1(123).await.unwrap();
+    let result = handler.get_fixed_redis_versions(123).await.unwrap();
 
     assert!(result.redis_versions.is_some());
     let versions = result.redis_versions.unwrap();
@@ -211,7 +211,7 @@ async fn test_get_all_subscriptions() {
         .unwrap();
 
     let handler = FixedSubscriptionsHandler::new(client);
-    let result = handler.get_all_subscriptions_1().await.unwrap();
+    let result = handler.get_all_fixed_subscriptions().await.unwrap();
 
     assert_eq!(result.account_id, Some(456));
     assert!(result.extra.get("subscriptions").is_some());
@@ -255,7 +255,7 @@ async fn test_create_subscription() {
         extra: serde_json::Value::Null,
     };
 
-    let result = handler.create_subscription_1(&request).await.unwrap();
+    let result = handler.create_fixed_subscription(&request).await.unwrap();
     assert_eq!(result.task_id, Some("task-create-fixed-sub".to_string()));
 }
 
@@ -284,7 +284,7 @@ async fn test_delete_subscription_by_id() {
         .unwrap();
 
     let handler = FixedSubscriptionsHandler::new(client);
-    let result = handler.delete_subscription_by_id_1(123).await.unwrap();
+    let result = handler.delete_fixed_subscription_by_id(123).await.unwrap();
 
     assert_eq!(result.task_id, Some("task-delete-fixed-sub".to_string()));
 }
@@ -317,7 +317,7 @@ async fn test_get_subscription_by_id() {
         .unwrap();
 
     let handler = FixedSubscriptionsHandler::new(client);
-    let result = handler.get_subscription_by_id_1(123).await.unwrap();
+    let result = handler.get_fixed_subscription_by_id(123).await.unwrap();
 
     assert_eq!(result.id, Some(123));
     assert_eq!(result.name, Some("Production Fixed".to_string()));
@@ -358,7 +358,10 @@ async fn test_update_subscription() {
         extra: serde_json::Value::Null,
     };
 
-    let result = handler.update_subscription_1(123, &request).await.unwrap();
+    let result = handler
+        .update_fixed_subscription(123, &request)
+        .await
+        .unwrap();
     assert_eq!(result.task_id, Some("task-update-fixed-sub".to_string()));
 }
 
@@ -382,7 +385,7 @@ async fn test_error_handling_401() {
         .unwrap();
 
     let handler = FixedSubscriptionsHandler::new(client);
-    let result = handler.get_all_subscriptions_1().await;
+    let result = handler.get_all_fixed_subscriptions().await;
 
     assert!(result.is_err());
     match result {
@@ -413,7 +416,7 @@ async fn test_error_handling_404() {
         .unwrap();
 
     let handler = FixedSubscriptionsHandler::new(client);
-    let result = handler.get_subscription_by_id_1(999).await;
+    let result = handler.get_fixed_subscription_by_id(999).await;
 
     assert!(result.is_err());
     if let Err(redis_cloud::CloudError::NotFound { message }) = result {
@@ -454,7 +457,7 @@ async fn test_error_handling_500() {
         extra: serde_json::Value::Null,
     };
 
-    let result = handler.create_subscription_1(&request).await;
+    let result = handler.create_fixed_subscription(&request).await;
 
     assert!(result.is_err());
     match result {

--- a/crates/redis-cloud/tests/subscriptions_tests.rs
+++ b/crates/redis-cloud/tests/subscriptions_tests.rs
@@ -239,7 +239,7 @@ async fn test_update_subscription() {
 }
 
 #[tokio::test]
-async fn test_get_cidr_white_list() {
+async fn test_get_cidr_allowlist() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
@@ -265,13 +265,13 @@ async fn test_get_cidr_white_list() {
         .unwrap();
 
     let handler = SubscriptionsHandler::new(client);
-    let result = handler.get_cidr_white_list(123).await.unwrap();
+    let result = handler.get_cidr_allowlist(123).await.unwrap();
 
     assert!(result.response.is_some());
 }
 
 #[tokio::test]
-async fn test_update_subscription_cidr_white_list() {
+async fn test_update_subscription_cidr_allowlist() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("PUT"))
@@ -294,7 +294,7 @@ async fn test_update_subscription_cidr_white_list() {
         .unwrap();
 
     let handler = SubscriptionsHandler::new(client);
-    let request = redis_cloud::subscriptions::CidrWhiteListUpdateRequest {
+    let request = redis_cloud::subscriptions::CidrAllowlistUpdateRequest {
         subscription_id: None,
         cidr_ips: Some(vec!["192.168.0.0/16".to_string()]),
         security_group_ids: None,
@@ -303,7 +303,7 @@ async fn test_update_subscription_cidr_white_list() {
     };
 
     let result = handler
-        .update_subscription_cidr_white_list(123, &request)
+        .update_subscription_cidr_allowlist(123, &request)
         .await
         .unwrap();
     assert_eq!(result.task_id, Some("task-update-cidr".to_string()));


### PR DESCRIPTION
## Summary
Fixes all the naming issues identified in #124 and #125 by removing confusing `_1` suffixes, fixing typos, and modernizing terminology.

## Changes

### 🏷️ Removed `_1` Suffixes
**Fixed Databases** - Now use `fixed_` prefix:
- `backup_database_1` → `backup_fixed_database`
- `get_tags_1` → `get_fixed_database_tags`
- `delete_fixed_database_by_id_1` → `delete_fixed_database_by_id`
- And 9 more methods...

**Fixed Subscriptions** - Now use `fixed_` prefix:
- `get_all_subscriptions_1` → `get_all_fixed_subscriptions`
- `create_subscription_1` → `create_fixed_subscription`
- And 4 more methods...

**ACL Module** - Now use `acl_` prefix to distinguish from account users:
- `get_all_users_1` → `get_all_acl_users`
- `update_user_1` → `update_acl_user`

### ✏️ Fixed Typos
**Connectivity Module**:
- `get_active_activ_psc_service_endpoint_creation_script` → `get_active_active_psc_service_endpoint_creation_script`
- `get_active_activ_psc_service_endpoint_deletion_script` → `get_active_active_psc_service_endpoint_deletion_script`

### 🔄 Modernized Terminology
**whitelist → allowlist**:
- `get_cidr_white_list` → `get_cidr_allowlist`
- `update_subscription_cidr_white_list` → `update_subscription_cidr_allowlist`
- `CidrWhiteListUpdateRequest` → `CidrAllowlistUpdateRequest`
- Updated all documentation comments

## Testing
- ✅ All 183 tests pass
- ✅ cargo fmt applied
- ✅ cargo clippy clean

## Breaking Changes
⚠️ **This is a breaking change** for the redis-cloud crate API. All method names have changed to be more descriptive and consistent.

Closes #124
Closes #125