### PR TITLE
fix: correct documentation errors and remove non-existent commands

### DIFF
--- a/docs/src/cli/configuration.md
+++ b/docs/src/cli/configuration.md
@@ -117,13 +117,13 @@ redisctl profile list
 ```bash
 # Create or update a Redis Cloud profile
 redisctl profile set my-cloud \
-  --deployment-type cloud \
+  --deployment cloud \
   --api-key "your-api-key" \
   --api-secret "your-api-secret"
 
 # Create or update a Redis Enterprise profile
 redisctl profile set my-enterprise \
-  --deployment-type enterprise \
+  --deployment enterprise \
   --url "https://cluster.example.com:9443" \
   --username "admin@cluster.local" \
   --password "secure-password" \
@@ -348,7 +348,7 @@ mkdir -p ~/.config/redisctl
 touch ~/.config/redisctl/config.toml
 
 # Or let redisctl create it
-redisctl profile set default --deployment-type cloud
+redisctl profile set default --deployment cloud
 ```
 
 ### Permission Denied

--- a/docs/src/cli/examples-detailed.md
+++ b/docs/src/cli/examples-detailed.md
@@ -20,13 +20,13 @@ Comprehensive examples for common Redis Cloud and Enterprise operations.
 ```bash
 # Create a Redis Cloud profile
 redisctl profile set cloud-prod \
-  --deployment-type cloud \
+  --deployment cloud \
   --api-key YOUR_API_KEY \
   --api-secret YOUR_API_SECRET
 
 # Create a Redis Enterprise profile
 redisctl profile set enterprise-dev \
-  --deployment-type enterprise \
+  --deployment enterprise \
   --url https://cluster.example.com:9443 \
   --username admin@example.com \
   --password SecurePassword123

--- a/docs/src/getting-started/authentication.md
+++ b/docs/src/getting-started/authentication.md
@@ -1,136 +1,55 @@
 # Authentication
 
-`redisctl` supports authentication for both Redis Cloud and Redis Enterprise deployments. This guide covers how to obtain and configure authentication credentials for each deployment type.
+`redisctl` supports authentication for both Redis Cloud and Redis Enterprise deployments.
 
-## Redis Cloud Authentication
+## Redis Cloud
 
-Redis Cloud uses API key authentication with two components:
-- **API Key** (Account Key) - Public identifier for your account
-- **API Secret** (Secret Key) - Private secret for authentication
+Redis Cloud uses API key authentication:
+- **API Key** - Your account key (public identifier)
+- **API Secret** - Your secret key (keep this private!)
 
-### Obtaining Cloud API Credentials
+### Getting Your API Keys
 
-1. **Log in to Redis Cloud Console**
-   - Navigate to [app.redislabs.com](https://app.redislabs.com)
-   - Sign in with your account credentials
+1. Log in to [app.redislabs.com](https://app.redislabs.com)
+2. Click your name → Account Settings → API Keys
+3. Click "Add API Key" and give it a name
+4. Copy both the Account key and Secret (you won't see the secret again!)
 
-2. **Access API Keys**
-   - Click on your name in the top-right corner
-   - Select "Account Settings"
-   - Navigate to the "API Keys" tab
+### Setting Up Authentication
 
-3. **Create New API Key**
-   - Click "Add API Key"
-   - Provide a descriptive name (e.g., "redisctl-cli")
-   - Select appropriate permissions:
-     - **Read-Only**: For viewing resources only
-     - **Read-Write**: For full management capabilities
-   - Click "Create"
-
-4. **Save Credentials**
-   - Copy the **Account key** (this is your API key)
-   - Copy the **Secret** (shown only once!)
-   - Store these securely - you won't be able to see the secret again
-
-### Configuring Cloud Authentication
-
-#### Using Profiles (Recommended)
+Use environment variables:
 
 ```bash
-# Create a profile with your credentials
-redisctl profile set my-cloud \
-  --deployment-type cloud \
-  --api-key "your-account-key" \
-  --api-secret "your-secret-key"
-
-# Set as default profile
-redisctl profile default my-cloud
-
-# Test authentication
-redisctl cloud account info
-```
-
-#### Using Environment Variables
-
-```bash
-# Export credentials
 export REDIS_CLOUD_API_KEY="your-account-key"
 export REDIS_CLOUD_API_SECRET="your-secret-key"
 
-# Optional: Set custom API URL
-export REDIS_CLOUD_API_URL="https://api.redislabs.com/v1"
-
-# Test authentication
-redisctl cloud account info
+# Test it works
+redisctl api cloud get /account
 ```
 
-#### Using Command-Line Flags
+Or create a configuration file at `~/.config/redisctl/config.toml`:
 
-```bash
-# Pass credentials directly (not recommended for production)
-redisctl cloud subscription list \
-  --api-key "your-account-key" \
-  --api-secret "your-secret-key"
+```toml
+[profiles.cloud]
+deployment_type = "cloud"
+api_key = "your-account-key"
+api_secret = "your-secret-key"
 ```
 
-## Redis Enterprise Authentication
+## Redis Enterprise
 
-Redis Enterprise uses basic authentication with username and password. The username typically follows an email format.
+Redis Enterprise uses basic authentication with username/password.
 
 ### Default Credentials
 
-For new Redis Enterprise installations:
-- **Username**: `admin@cluster.local`
+- **Username**: `admin@cluster.local` (default)
 - **Password**: Set during cluster setup
 
-### Obtaining Enterprise Credentials
+### Setting Up Authentication
 
-1. **During Cluster Setup**
-   - Credentials are set during initial cluster configuration
-   - Default username is typically `admin@cluster.local`
-
-2. **From Cluster Administrator**
-   - Contact your Redis Enterprise administrator
-   - Request appropriate user credentials
-   - Ensure your user has necessary permissions
-
-3. **Creating New Users** (if you're an admin)
-   ```bash
-   # Using redisctl to create a new user
-   redisctl enterprise user create \
-     --email "newuser@example.com" \
-     --password "secure-password" \
-     --role "admin"
-   ```
-
-### Configuring Enterprise Authentication
-
-#### Using Profiles (Recommended)
+Use environment variables:
 
 ```bash
-# Create a profile for Enterprise cluster
-redisctl profile set my-enterprise \
-  --deployment-type enterprise \
-  --url "https://cluster.example.com:9443" \
-  --username "admin@cluster.local" \
-  --password "your-password"
-
-# For self-signed certificates, add --insecure
-redisctl profile set dev-cluster \
-  --deployment-type enterprise \
-  --url "https://localhost:9443" \
-  --username "admin@cluster.local" \
-  --password "your-password" \
-  --insecure
-
-# Test authentication
-redisctl enterprise cluster info
-```
-
-#### Using Environment Variables
-
-```bash
-# Export credentials
 export REDIS_ENTERPRISE_URL="https://cluster.example.com:9443"
 export REDIS_ENTERPRISE_USER="admin@cluster.local"
 export REDIS_ENTERPRISE_PASSWORD="your-password"
@@ -138,203 +57,53 @@ export REDIS_ENTERPRISE_PASSWORD="your-password"
 # For self-signed certificates
 export REDIS_ENTERPRISE_INSECURE="true"
 
-# Test authentication
-redisctl enterprise cluster info
+# Test it works
+redisctl api enterprise get /v1/cluster
 ```
 
-## Security Best Practices
+Or add to `~/.config/redisctl/config.toml`:
 
-### 1. Never Hardcode Credentials
+```toml
+[profiles.enterprise]
+deployment_type = "enterprise"
+url = "https://cluster.example.com:9443"
+username = "admin@cluster.local"
+password = "your-password"
+insecure = true  # For self-signed certs
+```
 
+## Security Tips
+
+1. **Never commit credentials** - Use environment variables or secure vaults
+2. **Use read-only API keys** when possible for Cloud
+3. **Rotate credentials regularly**
+4. **Set file permissions**: `chmod 600 ~/.config/redisctl/config.toml`
+
+## Troubleshooting
+
+### Authentication Failed
+
+Check your credentials:
 ```bash
-# Bad - credentials in shell history
-redisctl cloud subscription list --api-key "abc123" --api-secret "xyz789"
-
-# Good - use profiles or environment variables
-redisctl cloud subscription list
+# Enable debug logging to see what's happening
+RUST_LOG=debug redisctl api cloud get /account
 ```
 
-### 2. Use Environment Variables in CI/CD
+### Connection Refused
 
-```yaml
-# GitHub Actions example
-env:
-  REDIS_CLOUD_API_KEY: ${{ secrets.REDIS_API_KEY }}
-  REDIS_CLOUD_API_SECRET: ${{ secrets.REDIS_API_SECRET }}
-
-# GitLab CI example
-variables:
-  REDIS_CLOUD_API_KEY: ${REDIS_API_KEY}
-  REDIS_CLOUD_API_SECRET: ${REDIS_API_SECRET}
-```
-
-### 3. Rotate Credentials Regularly
-
+Verify the URL and port are correct:
 ```bash
-# Cloud: Create new API key periodically
-# 1. Create new key in Redis Cloud Console
-# 2. Update profile with new credentials
-redisctl profile set production \
-  --api-key "new-key" \
-  --api-secret "new-secret"
-
-# 3. Test new credentials
-redisctl cloud account info
-
-# 4. Delete old key from Redis Cloud Console
+curl -k https://your-cluster:9443/v1/cluster
 ```
 
-### 4. Use Minimal Required Permissions
+### Certificate Errors
 
-For Redis Cloud API keys:
-- **Read-Only** for monitoring and reporting tasks
-- **Read-Write** only when management operations are needed
-- **Subscription-specific** keys when available
-
-For Redis Enterprise users:
-- Use role-based access control (RBAC)
-- Assign minimum required role
-- Create service-specific users
-
-### 5. Secure Storage of Credentials
-
+For development/testing with self-signed certificates:
 ```bash
-# Use secure secret management tools
-# Example with 1Password CLI
-export REDIS_CLOUD_API_KEY=$(op read "op://vault/redis-cloud/api-key")
-export REDIS_CLOUD_API_SECRET=$(op read "op://vault/redis-cloud/api-secret")
-
-# Example with AWS Secrets Manager
-export REDIS_CLOUD_API_KEY=$(aws secretsmanager get-secret-value \
-  --secret-id redis/cloud/api-key \
-  --query SecretString --output text)
-```
-
-## Testing Authentication
-
-### Verify Cloud Authentication
-
-```bash
-# Test with account info
-redisctl cloud account info
-
-# If successful, you'll see account details
-# {
-#   "accountId": 12345,
-#   "name": "My Company",
-#   ...
-# }
-
-# Test with a simple list operation
-redisctl cloud subscription list
-```
-
-### Verify Enterprise Authentication
-
-```bash
-# Test with cluster info
-redisctl enterprise cluster info
-
-# If successful, you'll see cluster details
-# {
-#   "name": "my-cluster",
-#   "version": "7.4.2",
-#   ...
-# }
-
-# Test with node list
-redisctl enterprise node list
-```
-
-### Authentication Test Command
-
-```bash
-# Test current profile authentication
-redisctl auth test
-
-# Test specific profile
-redisctl auth test --profile production
-
-# Verbose output for debugging
-RUST_LOG=debug redisctl auth test
-```
-
-## Troubleshooting Authentication Issues
-
-### Redis Cloud
-
-#### Invalid API Key or Secret
-
-```bash
-# Error: Authentication failed: 401 Unauthorized
-# Solution: Verify credentials are correct
-redisctl profile get my-cloud
-
-# Re-enter credentials if needed
-redisctl profile set my-cloud \
-  --api-key "correct-key" \
-  --api-secret "correct-secret"
-```
-
-#### API Key Lacks Permissions
-
-```bash
-# Error: Forbidden: API key lacks required permissions
-# Solution: Create new key with appropriate permissions in Redis Cloud Console
-```
-
-### Redis Enterprise
-
-#### Connection Refused
-
-```bash
-# Error: Connection refused
-# Solution: Verify URL and port
-curl -k https://cluster.example.com:9443/v1/cluster
-
-# Check if cluster is accessible
-ping cluster.example.com
-```
-
-#### Invalid Credentials
-
-```bash
-# Error: Authentication failed: 401 Unauthorized
-# Solution: Verify username and password
-redisctl profile set my-enterprise \
-  --username "correct-user@domain.com" \
-  --password "correct-password"
-```
-
-#### SSL Certificate Issues
-
-```bash
-# Error: Certificate verify failed
-# Solution for development/testing only:
 export REDIS_ENTERPRISE_INSECURE=true
-
-# Or update profile:
-redisctl profile set dev-cluster --insecure
 ```
-
-## Multi-Factor Authentication (MFA)
-
-### Redis Cloud with SSO
-
-If your Redis Cloud account uses SSO with MFA:
-1. API keys bypass SSO/MFA for programmatic access
-2. Create API keys through the web console after SSO login
-3. Use API keys with `redisctl` as normal
-
-### Redis Enterprise with LDAP
-
-If your Redis Enterprise cluster uses LDAP with MFA:
-1. Local users (non-LDAP) can be created for CLI access
-2. Contact your administrator to create a service account
-3. Use the service account credentials with `redisctl`
 
 ## See Also
 
-- [Configuration](../cli/configuration.md) - Profile management and configuration
-- [Profile Commands](../cli-reference/profile/README.md) - Profile command reference
-- [Quick Start](./quickstart.md) - Getting started with redisctl
+- [Configuration](../cli/configuration.md) - Profile management
+- [Environment Variables](../cli/environment-variables.md) - All supported variables


### PR DESCRIPTION
## Summary

Fixes immediate documentation errors identified in #132.

## Changes

### Fixed Incorrect Command Flags
- Changed `--deployment-type` to `--deployment` (the correct flag name)
- Fixed in authentication.md, configuration.md, and examples-detailed.md

### Removed Non-Existent Commands
- Removed references to `auth setup` command (doesn't exist)
- Removed references to `auth test` command (doesn't exist)
- Replaced with actual working commands for testing authentication

### Simplified Authentication Documentation
- Removed complex multi-section structure
- Focused on what actually works
- Added clear examples using `api` command for testing

## Testing

✅ Verified `--deployment` is the correct flag:
```bash
cargo run -- profile set --help
# Shows: --deployment <DEPLOYMENT>
```

✅ Confirmed `auth` subcommand doesn't exist:
```bash
cargo run -- auth
# Error: unrecognized subcommand 'auth'
```

✅ Documentation builds successfully with mdbook

## Related Issues

Partially addresses #132 - This PR handles the immediate fixes. Full documentation refresh will follow in separate PRs.

## Next Steps

After this PR:
1. Add complete config.toml example to README
2. Begin comprehensive documentation restructuring per #132