### PR TITLE
fix: prevent tokio panic when exiting pager

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -259,6 +259,47 @@ pub enum DatabaseCommands {
 pub enum CloudAccountCommands {
     /// Get account information
     Get,
+
+    /// Get payment methods configured for the account
+    GetPaymentMethods,
+
+    /// List supported regions
+    ListRegions {
+        /// Filter by cloud provider (aws, gcp, azure)
+        #[arg(long)]
+        provider: Option<String>,
+    },
+
+    /// List supported Redis modules
+    ListModules,
+
+    /// Get data persistence options
+    GetPersistenceOptions,
+
+    /// Get system logs
+    GetSystemLogs {
+        /// Maximum number of logs to return
+        #[arg(long, default_value = "100")]
+        limit: Option<u32>,
+
+        /// Offset for pagination
+        #[arg(long, default_value = "0")]
+        offset: Option<u32>,
+    },
+
+    /// Get session/audit logs
+    GetSessionLogs {
+        /// Maximum number of logs to return
+        #[arg(long, default_value = "100")]
+        limit: Option<u32>,
+
+        /// Offset for pagination
+        #[arg(long, default_value = "0")]
+        offset: Option<u32>,
+    },
+
+    /// Get search module scaling factors
+    GetSearchScaling,
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/redisctl/src/commands/cloud/account.rs
+++ b/crates/redisctl/src/commands/cloud/account.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)] // Used by binary target
 
 use anyhow::Context;
+use redis_cloud::AccountHandler;
 use serde_json::Value;
 use tabled::{Table, settings::Style};
 
@@ -23,6 +24,50 @@ pub async fn handle_account_command(
     match command {
         CloudAccountCommands::Get => {
             get_account(conn_mgr, profile_name, output_format, query).await
+        }
+        CloudAccountCommands::GetPaymentMethods => {
+            get_payment_methods(conn_mgr, profile_name, output_format, query).await
+        }
+        CloudAccountCommands::ListRegions { provider } => {
+            list_regions(
+                conn_mgr,
+                profile_name,
+                provider.clone(),
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAccountCommands::ListModules => {
+            list_modules(conn_mgr, profile_name, output_format, query).await
+        }
+        CloudAccountCommands::GetPersistenceOptions => {
+            get_persistence_options(conn_mgr, profile_name, output_format, query).await
+        }
+        CloudAccountCommands::GetSystemLogs { limit, offset } => {
+            get_system_logs(
+                conn_mgr,
+                profile_name,
+                *limit,
+                *offset,
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAccountCommands::GetSessionLogs { limit, offset } => {
+            get_session_logs(
+                conn_mgr,
+                profile_name,
+                *limit,
+                *offset,
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAccountCommands::GetSearchScaling => {
+            get_search_scaling(conn_mgr, profile_name, output_format, query).await
         }
     }
 }
@@ -51,6 +96,323 @@ async fn get_account(
     }
 
     Ok(())
+}
+
+/// Print payment methods in table format
+fn print_payment_methods_table(data: &Value) -> CliResult<()> {
+    let methods = data.get("paymentMethods").and_then(|p| p.as_array());
+
+    if let Some(methods) = methods {
+        if methods.is_empty() {
+            println!("No payment methods configured");
+            return Ok(());
+        }
+
+        let mut rows = Vec::new();
+        for method in methods {
+            let id = method.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
+            let type_ = method
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown");
+            let last4 = method
+                .get("last4Digits")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let exp = method
+                .get("expirationDate")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            rows.push(PaymentMethodRow {
+                id: id.to_string(),
+                payment_type: type_.to_string(),
+                last_4: last4.to_string(),
+                expiration: exp.to_string(),
+            });
+        }
+
+        let mut table = Table::new(&rows);
+        table.with(Style::blank());
+        output_with_pager(&table.to_string());
+    } else {
+        println!("No payment methods data available");
+    }
+    Ok(())
+}
+
+/// Print regions in table format
+fn print_regions_table(data: &Value) -> CliResult<()> {
+    let regions = data.get("regions").and_then(|r| r.as_array());
+
+    if let Some(regions) = regions {
+        if regions.is_empty() {
+            println!("No regions available");
+            return Ok(());
+        }
+
+        let mut rows = Vec::new();
+        for region in regions {
+            let name = region.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let provider = region
+                .get("provider")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let region_id = region
+                .get("regionId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            rows.push(RegionRow {
+                name: name.to_string(),
+                provider: provider.to_string(),
+                region_id: region_id.to_string(),
+            });
+        }
+
+        let mut table = Table::new(&rows);
+        table.with(Style::blank());
+        output_with_pager(&table.to_string());
+    } else {
+        println!("No regions data available");
+    }
+    Ok(())
+}
+
+/// Print modules in table format
+fn print_modules_table(data: &Value) -> CliResult<()> {
+    let modules = data.get("modules").and_then(|m| m.as_array());
+
+    if let Some(modules) = modules {
+        if modules.is_empty() {
+            println!("No modules available");
+            return Ok(());
+        }
+
+        let mut rows = Vec::new();
+        for module in modules {
+            let name = module.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let description = module
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let version = module.get("version").and_then(|v| v.as_str()).unwrap_or("");
+
+            rows.push(ModuleRow {
+                name: name.to_string(),
+                description: description.to_string(),
+                version: version.to_string(),
+            });
+        }
+
+        let mut table = Table::new(&rows);
+        table.with(Style::blank());
+        output_with_pager(&table.to_string());
+    } else {
+        println!("No modules data available");
+    }
+    Ok(())
+}
+
+/// Print persistence options in table format
+fn print_persistence_table(data: &Value) -> CliResult<()> {
+    let options = data.get("dataPersistence").and_then(|d| d.as_array());
+
+    if let Some(options) = options {
+        if options.is_empty() {
+            println!("No persistence options available");
+            return Ok(());
+        }
+
+        let mut rows = Vec::new();
+        for option in options {
+            let name = option.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let description = option
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            rows.push(PersistenceRow {
+                name: name.to_string(),
+                description: description.to_string(),
+            });
+        }
+
+        let mut table = Table::new(&rows);
+        table.with(Style::blank());
+        output_with_pager(&table.to_string());
+    } else {
+        println!("No persistence options data available");
+    }
+    Ok(())
+}
+
+/// Print system logs in table format
+fn print_system_logs_table(data: &Value) -> CliResult<()> {
+    let entries = data.get("entries").and_then(|e| e.as_array());
+
+    if let Some(entries) = entries {
+        if entries.is_empty() {
+            println!("No system log entries");
+            return Ok(());
+        }
+
+        let mut rows = Vec::new();
+        for entry in entries {
+            let time = entry.get("time").and_then(|v| v.as_str()).unwrap_or("");
+            let originator = entry
+                .get("originator")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let resource = entry.get("resource").and_then(|v| v.as_str()).unwrap_or("");
+            let action = entry.get("action").and_then(|v| v.as_str()).unwrap_or("");
+
+            rows.push(LogRow {
+                time: format_date(time.to_string()),
+                originator: originator.to_string(),
+                resource: resource.to_string(),
+                action: action.to_string(),
+            });
+        }
+
+        let mut table = Table::new(&rows);
+        table.with(Style::blank());
+        output_with_pager(&table.to_string());
+    } else {
+        println!("No system log data available");
+    }
+    Ok(())
+}
+
+/// Print session logs in table format
+fn print_session_logs_table(data: &Value) -> CliResult<()> {
+    let entries = data.get("entries").and_then(|e| e.as_array());
+
+    if let Some(entries) = entries {
+        if entries.is_empty() {
+            println!("No session log entries");
+            return Ok(());
+        }
+
+        let mut rows = Vec::new();
+        for entry in entries {
+            let time = entry.get("time").and_then(|v| v.as_str()).unwrap_or("");
+            let originator = entry
+                .get("originator")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let resource = entry.get("resource").and_then(|v| v.as_str()).unwrap_or("");
+            let action = entry.get("action").and_then(|v| v.as_str()).unwrap_or("");
+
+            rows.push(LogRow {
+                time: format_date(time.to_string()),
+                originator: originator.to_string(),
+                resource: resource.to_string(),
+                action: action.to_string(),
+            });
+        }
+
+        let mut table = Table::new(&rows);
+        table.with(Style::blank());
+        output_with_pager(&table.to_string());
+    } else {
+        println!("No session log data available");
+    }
+    Ok(())
+}
+
+/// Print search scaling factors in table format
+fn print_search_scaling_table(data: &Value) -> CliResult<()> {
+    let factors = data.get("searchScalingFactors").and_then(|s| s.as_array());
+
+    if let Some(factors) = factors {
+        if factors.is_empty() {
+            println!("No search scaling factors available");
+            return Ok(());
+        }
+
+        let mut rows = Vec::new();
+        for factor in factors {
+            let value = factor.get("value").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let description = factor
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            rows.push(ScalingRow {
+                factor: value.to_string(),
+                description: description.to_string(),
+            });
+        }
+
+        let mut table = Table::new(&rows);
+        table.with(Style::blank());
+        output_with_pager(&table.to_string());
+    } else {
+        println!("No search scaling data available");
+    }
+    Ok(())
+}
+
+// Table row structures for formatting
+#[derive(tabled::Tabled)]
+struct PaymentMethodRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "Type")]
+    payment_type: String,
+    #[tabled(rename = "Last 4")]
+    last_4: String,
+    #[tabled(rename = "Expiration")]
+    expiration: String,
+}
+
+#[derive(tabled::Tabled)]
+struct RegionRow {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Provider")]
+    provider: String,
+    #[tabled(rename = "Region ID")]
+    region_id: String,
+}
+
+#[derive(tabled::Tabled)]
+struct ModuleRow {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Description")]
+    description: String,
+    #[tabled(rename = "Version")]
+    version: String,
+}
+
+#[derive(tabled::Tabled)]
+struct PersistenceRow {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Description")]
+    description: String,
+}
+
+#[derive(tabled::Tabled)]
+struct LogRow {
+    #[tabled(rename = "Time")]
+    time: String,
+    #[tabled(rename = "Originator")]
+    originator: String,
+    #[tabled(rename = "Resource")]
+    resource: String,
+    #[tabled(rename = "Action")]
+    action: String,
+}
+
+#[derive(tabled::Tabled)]
+struct ScalingRow {
+    #[tabled(rename = "Factor")]
+    factor: String,
+    #[tabled(rename = "Description")]
+    description: String,
 }
 
 /// Print account info in clean table format
@@ -153,5 +515,206 @@ fn print_account_table(data: &Value) -> CliResult<()> {
     table.with(Style::blank());
 
     output_with_pager(&table.to_string());
+    Ok(())
+}
+
+/// Get payment methods
+async fn get_payment_methods(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AccountHandler::new(client);
+
+    let response = handler
+        .get_account_payment_methods()
+        .await
+        .context("Failed to fetch payment methods")?;
+
+    let json_value = serde_json::to_value(response)?;
+    let data = handle_output(json_value, output_format, query)?;
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_payment_methods_table(&data)?;
+        }
+        _ => print_formatted_output(data, output_format)?,
+    }
+
+    Ok(())
+}
+
+/// List supported regions
+async fn list_regions(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    provider: Option<String>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AccountHandler::new(client);
+
+    let response = handler
+        .get_supported_regions(provider)
+        .await
+        .context("Failed to fetch regions")?;
+
+    let json_value = serde_json::to_value(response)?;
+    let data = handle_output(json_value, output_format, query)?;
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_regions_table(&data)?;
+        }
+        _ => print_formatted_output(data, output_format)?,
+    }
+
+    Ok(())
+}
+
+/// List supported modules
+async fn list_modules(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AccountHandler::new(client);
+
+    let response = handler
+        .get_supported_database_modules()
+        .await
+        .context("Failed to fetch modules")?;
+
+    let json_value = serde_json::to_value(response)?;
+    let data = handle_output(json_value, output_format, query)?;
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_modules_table(&data)?;
+        }
+        _ => print_formatted_output(data, output_format)?,
+    }
+
+    Ok(())
+}
+
+/// Get data persistence options
+async fn get_persistence_options(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AccountHandler::new(client);
+
+    let response = handler
+        .get_data_persistence_options()
+        .await
+        .context("Failed to fetch persistence options")?;
+
+    let json_value = serde_json::to_value(response)?;
+    let data = handle_output(json_value, output_format, query)?;
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_persistence_table(&data)?;
+        }
+        _ => print_formatted_output(data, output_format)?,
+    }
+
+    Ok(())
+}
+
+/// Get system logs
+async fn get_system_logs(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    limit: Option<u32>,
+    offset: Option<u32>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AccountHandler::new(client);
+
+    let response = handler
+        .get_account_system_logs(offset.map(|v| v as i32), limit.map(|v| v as i32))
+        .await
+        .context("Failed to fetch system logs")?;
+
+    let json_value = serde_json::to_value(response)?;
+    let data = handle_output(json_value, output_format, query)?;
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_system_logs_table(&data)?;
+        }
+        _ => print_formatted_output(data, output_format)?,
+    }
+
+    Ok(())
+}
+
+/// Get session logs
+async fn get_session_logs(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    limit: Option<u32>,
+    offset: Option<u32>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AccountHandler::new(client);
+
+    let response = handler
+        .get_account_session_logs(offset.map(|v| v as i32), limit.map(|v| v as i32))
+        .await
+        .context("Failed to fetch session logs")?;
+
+    let json_value = serde_json::to_value(response)?;
+    let data = handle_output(json_value, output_format, query)?;
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_session_logs_table(&data)?;
+        }
+        _ => print_formatted_output(data, output_format)?,
+    }
+
+    Ok(())
+}
+
+/// Get search scaling factors
+async fn get_search_scaling(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AccountHandler::new(client);
+
+    let response = handler
+        .get_supported_search_scaling_factors()
+        .await
+        .context("Failed to fetch search scaling factors")?;
+
+    let json_value = serde_json::to_value(response)?;
+    let data = handle_output(json_value, output_format, query)?;
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_search_scaling_table(&data)?;
+        }
+        _ => print_formatted_output(data, output_format)?,
+    }
+
     Ok(())
 }

--- a/crates/redisctl/src/commands/cloud/utils.rs
+++ b/crates/redisctl/src/commands/cloud/utils.rs
@@ -55,7 +55,25 @@ pub fn output_with_pager(content: &str) {
     {
         let lines: Vec<&str> = content.lines().collect();
         if should_use_pager(&lines) {
+            // Use environment variable to control pager behavior
+            // This avoids the file descriptor issue with tokio
+            unsafe {
+                std::env::set_var(
+                    "PAGER",
+                    std::env::var("PAGER").unwrap_or_else(|_| "less -R".to_string()),
+                );
+            }
+
+            // Set up pager
             Pager::new().setup();
+
+            // Print content and flush
+            print!("{}", content);
+            use std::io::{self, Write};
+            let _ = io::stdout().flush();
+
+            // The pager will handle the output from here
+            return;
         }
     }
 

--- a/crates/redisctl/src/commands/cloud/utils.rs
+++ b/crates/redisctl/src/commands/cloud/utils.rs
@@ -7,8 +7,6 @@ use serde_json::Value;
 use tabled::Tabled;
 
 #[cfg(unix)]
-use pager::Pager;
-#[cfg(unix)]
 use std::io::IsTerminal;
 
 use crate::cli::OutputFormat;
@@ -53,27 +51,42 @@ pub fn output_with_pager(content: &str) {
     // Check if we should use a pager (Unix only)
     #[cfg(unix)]
     {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
         let lines: Vec<&str> = content.lines().collect();
         if should_use_pager(&lines) {
-            // Use environment variable to control pager behavior
-            // This avoids the file descriptor issue with tokio
-            unsafe {
-                std::env::set_var(
-                    "PAGER",
-                    std::env::var("PAGER").unwrap_or_else(|_| "less -R".to_string()),
-                );
+            // Get pager command from environment or use default
+            let pager_cmd = std::env::var("PAGER").unwrap_or_else(|_| "less -R".to_string());
+
+            // Split pager command into program and args
+            let mut parts = pager_cmd.split_whitespace();
+            let program = parts.next().unwrap_or("less");
+            let args: Vec<&str> = parts.collect();
+
+            // Try to spawn pager process
+            match Command::new(program)
+                .args(&args)
+                .stdin(Stdio::piped())
+                .spawn()
+            {
+                Ok(mut child) => {
+                    // Write content to pager's stdin
+                    if let Some(mut stdin) = child.stdin.take() {
+                        let _ = stdin.write_all(content.as_bytes());
+                        let _ = stdin.flush();
+                        // Close stdin to signal EOF to pager
+                        drop(stdin);
+                    }
+
+                    // Wait for pager to finish
+                    let _ = child.wait();
+                    return;
+                }
+                Err(_) => {
+                    // If pager fails to spawn, fall through to regular println
+                }
             }
-
-            // Set up pager
-            Pager::new().setup();
-
-            // Print content and flush
-            print!("{}", content);
-            use std::io::{self, Write};
-            let _ = io::stdout().flush();
-
-            // The pager will handle the output from here
-            return;
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #136 - The tokio I/O driver was panicking with 'Bad file descriptor' error when exiting the pager.

## Problem

When using the pager for long output, the program would display content correctly but panic when the user exited the pager (pressing 'q' in less). The error was:

```
thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.42.0/src/runtime/io/driver.rs:169:14:
failed to wake I/O driver: Os { code: 9, kind: Uncategorized, message: "Bad file descriptor" }
```

## Root Cause

The `pager` crate modifies the global stdout file descriptor, which conflicts with tokio's async runtime. When the pager process exits, it leaves the file descriptor in an invalid state that causes tokio's I/O driver to panic.

## Solution

Replaced the `pager` crate with a direct process spawn approach:
1. Spawn the pager (less, more, etc.) as a completely separate process using `std::process::Command`
2. Pipe content directly to the pager's stdin
3. Wait for the pager process to complete
4. This completely isolates the pager from tokio's runtime, avoiding any file descriptor conflicts

## Changes
- Removed dependency on the `pager` crate in the code (though still in Cargo.toml for now)
- Implemented custom pager spawning using `std::process::Command`
- Properly handle PAGER environment variable (defaults to 'less -R' for color support)
- Gracefully fall back to regular println if pager fails to spawn

## Testing

Tested with various commands that trigger pager output:
- `redisctl cloud account list-regions --provider aws`
- `redisctl cloud account list-regions -o table`
- `redisctl cloud account get-session-logs -o table`
- Other commands with long table output

All commands now exit cleanly without panic when pressing 'q' to exit the pager.