### PR TITLE
feat(cloud): implement ACL commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -208,6 +208,10 @@ pub enum CloudCommands {
     /// User operations
     #[command(subcommand)]
     User(CloudUserCommands),
+
+    /// ACL (Access Control List) operations
+    #[command(subcommand)]
+    Acl(CloudAclCommands),
 }
 
 /// Enterprise-specific commands (placeholder for now)
@@ -564,6 +568,139 @@ pub enum CloudUserCommands {
     Get {
         /// User ID
         id: u32,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CloudAclCommands {
+    // Redis ACL Rules
+    /// List all Redis ACL rules
+    #[command(name = "list-redis-rules")]
+    ListRedisRules,
+
+    /// Create a new Redis ACL rule
+    #[command(name = "create-redis-rule")]
+    CreateRedisRule {
+        /// Rule name
+        #[arg(long)]
+        name: String,
+        /// Redis ACL rule (e.g., "+@read")
+        #[arg(long)]
+        rule: String,
+    },
+
+    /// Update an existing Redis ACL rule
+    #[command(name = "update-redis-rule")]
+    UpdateRedisRule {
+        /// Rule ID
+        id: i32,
+        /// New rule name
+        #[arg(long)]
+        name: Option<String>,
+        /// New Redis ACL rule
+        #[arg(long)]
+        rule: Option<String>,
+    },
+
+    /// Delete a Redis ACL rule
+    #[command(name = "delete-redis-rule")]
+    DeleteRedisRule {
+        /// Rule ID
+        id: i32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
+
+    // ACL Roles
+    /// List all ACL roles
+    #[command(name = "list-roles")]
+    ListRoles,
+
+    /// Create a new ACL role
+    #[command(name = "create-role")]
+    CreateRole {
+        /// Role name
+        #[arg(long)]
+        name: String,
+        /// Redis rules (JSON array or single rule ID)
+        #[arg(long, value_name = "JSON|ID")]
+        redis_rules: String,
+    },
+
+    /// Update an existing ACL role
+    #[command(name = "update-role")]
+    UpdateRole {
+        /// Role ID
+        id: i32,
+        /// New role name
+        #[arg(long)]
+        name: Option<String>,
+        /// New Redis rules (JSON array or single rule ID)
+        #[arg(long, value_name = "JSON|ID")]
+        redis_rules: Option<String>,
+    },
+
+    /// Delete an ACL role
+    #[command(name = "delete-role")]
+    DeleteRole {
+        /// Role ID
+        id: i32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
+
+    // ACL Users
+    /// List all ACL users
+    #[command(name = "list-acl-users")]
+    ListAclUsers,
+
+    /// Get ACL user details
+    #[command(name = "get-acl-user")]
+    GetAclUser {
+        /// ACL user ID
+        id: i32,
+    },
+
+    /// Create a new ACL user
+    #[command(name = "create-acl-user")]
+    CreateAclUser {
+        /// Username
+        #[arg(long)]
+        name: String,
+        /// Role name
+        #[arg(long)]
+        role: String,
+        /// Password
+        #[arg(long)]
+        password: String,
+    },
+
+    /// Update an ACL user
+    #[command(name = "update-acl-user")]
+    UpdateAclUser {
+        /// ACL user ID
+        id: i32,
+        /// New username
+        #[arg(long)]
+        name: Option<String>,
+        /// New role name
+        #[arg(long)]
+        role: Option<String>,
+        /// New password
+        #[arg(long)]
+        password: Option<String>,
+    },
+
+    /// Delete an ACL user
+    #[command(name = "delete-acl-user")]
+    DeleteAclUser {
+        /// ACL user ID
+        id: i32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
     },
 }
 

--- a/crates/redisctl/src/commands/cloud/acl.rs
+++ b/crates/redisctl/src/commands/cloud/acl.rs
@@ -1,0 +1,123 @@
+#![allow(dead_code)]
+
+use crate::cli::{CloudAclCommands, OutputFormat};
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+
+use super::acl_impl;
+
+pub async fn handle_acl_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &CloudAclCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    match command {
+        // Redis ACL Rules
+        CloudAclCommands::ListRedisRules => {
+            acl_impl::list_redis_rules(conn_mgr, profile_name, output_format, query).await
+        }
+        CloudAclCommands::CreateRedisRule { name, rule } => {
+            acl_impl::create_redis_rule(conn_mgr, profile_name, name, rule, output_format, query)
+                .await
+        }
+        CloudAclCommands::UpdateRedisRule { id, name, rule } => {
+            acl_impl::update_redis_rule(
+                conn_mgr,
+                profile_name,
+                *id,
+                name.as_deref(),
+                rule.as_deref(),
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAclCommands::DeleteRedisRule { id, force } => {
+            acl_impl::delete_redis_rule(conn_mgr, profile_name, *id, *force, output_format, query)
+                .await
+        }
+
+        // ACL Roles
+        CloudAclCommands::ListRoles => {
+            acl_impl::list_roles(conn_mgr, profile_name, output_format, query).await
+        }
+        CloudAclCommands::CreateRole { name, redis_rules } => {
+            acl_impl::create_role(
+                conn_mgr,
+                profile_name,
+                name,
+                redis_rules,
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAclCommands::UpdateRole {
+            id,
+            name,
+            redis_rules,
+        } => {
+            acl_impl::update_role(
+                conn_mgr,
+                profile_name,
+                *id,
+                name.as_deref(),
+                redis_rules.as_deref(),
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAclCommands::DeleteRole { id, force } => {
+            acl_impl::delete_role(conn_mgr, profile_name, *id, *force, output_format, query).await
+        }
+
+        // ACL Users
+        CloudAclCommands::ListAclUsers => {
+            acl_impl::list_acl_users(conn_mgr, profile_name, output_format, query).await
+        }
+        CloudAclCommands::GetAclUser { id } => {
+            acl_impl::get_acl_user(conn_mgr, profile_name, *id, output_format, query).await
+        }
+        CloudAclCommands::CreateAclUser {
+            name,
+            role,
+            password,
+        } => {
+            acl_impl::create_acl_user(
+                conn_mgr,
+                profile_name,
+                name,
+                role,
+                password,
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAclCommands::UpdateAclUser {
+            id,
+            name,
+            role,
+            password,
+        } => {
+            acl_impl::update_acl_user(
+                conn_mgr,
+                profile_name,
+                *id,
+                name.as_deref(),
+                role.as_deref(),
+                password.as_deref(),
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudAclCommands::DeleteAclUser { id, force } => {
+            acl_impl::delete_acl_user(conn_mgr, profile_name, *id, *force, output_format, query)
+                .await
+        }
+    }
+}

--- a/crates/redisctl/src/commands/cloud/acl_impl.rs
+++ b/crates/redisctl/src/commands/cloud/acl_impl.rs
@@ -1,0 +1,375 @@
+#![allow(dead_code)]
+
+use crate::cli::OutputFormat;
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+use anyhow::Context;
+use redis_cloud::acl::AclHandler;
+
+use super::utils::*;
+
+// Redis ACL Rules
+
+pub async fn list_redis_rules(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AclHandler::new(client);
+
+    let rules = handler.get_all_redis_rules().await?;
+    let rules_json = serde_json::to_value(rules).context("Failed to serialize Redis rules")?;
+    let data = handle_output(rules_json, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn create_redis_rule(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    name: &str,
+    rule: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    let request_data = serde_json::json!({
+        "name": name,
+        "rule": rule
+    });
+
+    let result = client
+        .post_raw("/acl/redis-rules", request_data)
+        .await
+        .context("Failed to create Redis rule")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn update_redis_rule(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    id: i32,
+    name: Option<&str>,
+    rule: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    let mut update_data = serde_json::Map::new();
+    if let Some(name) = name {
+        update_data.insert(
+            "name".to_string(),
+            serde_json::Value::String(name.to_string()),
+        );
+    }
+    if let Some(rule) = rule {
+        update_data.insert(
+            "rule".to_string(),
+            serde_json::Value::String(rule.to_string()),
+        );
+    }
+
+    let result = client
+        .put_raw(
+            &format!("/acl/redis-rules/{}", id),
+            serde_json::Value::Object(update_data),
+        )
+        .await
+        .context("Failed to update Redis rule")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn delete_redis_rule(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    id: i32,
+    force: bool,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    if !force {
+        let confirm = confirm_action(&format!("delete Redis rule {}", id))?;
+        if !confirm {
+            println!("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AclHandler::new(client.clone());
+
+    handler.delete_redis_rule(id).await?;
+
+    let result = serde_json::json!({
+        "message": format!("Redis rule {} deleted successfully", id)
+    });
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+// ACL Roles
+
+pub async fn list_roles(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AclHandler::new(client);
+
+    let roles = handler.get_roles().await?;
+    let roles_json = serde_json::to_value(roles).context("Failed to serialize roles")?;
+    let data = handle_output(roles_json, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn create_role(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    name: &str,
+    redis_rules: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    let rules_data = if redis_rules.starts_with('[') {
+        serde_json::from_str(redis_rules).context("Failed to parse redis-rules as JSON array")?
+    } else {
+        // If it's a single rule ID, wrap it in an array
+        serde_json::json!([{"rule_id": redis_rules.parse::<i32>().context("Invalid rule ID")?}])
+    };
+
+    let request_data = serde_json::json!({
+        "name": name,
+        "redis_rules": rules_data
+    });
+
+    let result = client
+        .post_raw("/acl/roles", request_data)
+        .await
+        .context("Failed to create role")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn update_role(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    id: i32,
+    name: Option<&str>,
+    redis_rules: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    let mut update_data = serde_json::Map::new();
+    if let Some(name) = name {
+        update_data.insert(
+            "name".to_string(),
+            serde_json::Value::String(name.to_string()),
+        );
+    }
+    if let Some(rules) = redis_rules {
+        let rules_data = if rules.starts_with('[') {
+            serde_json::from_str(rules).context("Failed to parse redis-rules as JSON array")?
+        } else {
+            serde_json::json!([{"rule_id": rules.parse::<i32>().context("Invalid rule ID")?}])
+        };
+        update_data.insert("redis_rules".to_string(), rules_data);
+    }
+
+    let result = client
+        .put_raw(
+            &format!("/acl/roles/{}", id),
+            serde_json::Value::Object(update_data),
+        )
+        .await
+        .context("Failed to update role")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn delete_role(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    id: i32,
+    force: bool,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    if !force {
+        let confirm = confirm_action(&format!("delete ACL role {}", id))?;
+        if !confirm {
+            println!("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AclHandler::new(client.clone());
+
+    handler.delete_acl_role(id).await?;
+
+    let result = serde_json::json!({
+        "message": format!("ACL role {} deleted successfully", id)
+    });
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+// ACL Users
+
+pub async fn list_acl_users(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AclHandler::new(client);
+
+    let users = handler.get_all_acl_users().await?;
+    let users_json = serde_json::to_value(users).context("Failed to serialize ACL users")?;
+    let data = handle_output(users_json, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn get_acl_user(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    id: i32,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AclHandler::new(client);
+
+    let user = handler.get_user_by_id(id).await?;
+    let user_json = serde_json::to_value(user).context("Failed to serialize ACL user")?;
+    let data = handle_output(user_json, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn create_acl_user(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    name: &str,
+    role: &str,
+    password: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    let request_data = serde_json::json!({
+        "name": name,
+        "role": role,
+        "password": password
+    });
+
+    let result = client
+        .post_raw("/acl/users", request_data)
+        .await
+        .context("Failed to create ACL user")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_acl_user(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    id: i32,
+    name: Option<&str>,
+    role: Option<&str>,
+    password: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    let mut update_data = serde_json::Map::new();
+    if let Some(name) = name {
+        update_data.insert(
+            "name".to_string(),
+            serde_json::Value::String(name.to_string()),
+        );
+    }
+    if let Some(role) = role {
+        update_data.insert(
+            "role".to_string(),
+            serde_json::Value::String(role.to_string()),
+        );
+    }
+    if let Some(password) = password {
+        update_data.insert(
+            "password".to_string(),
+            serde_json::Value::String(password.to_string()),
+        );
+    }
+
+    let result = client
+        .put_raw(
+            &format!("/acl/users/{}", id),
+            serde_json::Value::Object(update_data),
+        )
+        .await
+        .context("Failed to update ACL user")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn delete_acl_user(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    id: i32,
+    force: bool,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    if !force {
+        let confirm = confirm_action(&format!("delete ACL user {}", id))?;
+        if !confirm {
+            println!("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = AclHandler::new(client.clone());
+
+    handler.delete_user(id).await?;
+
+    let result = serde_json::json!({
+        "message": format!("ACL user {} deleted successfully", id)
+    });
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -8,6 +8,8 @@
 //! - `utils`: Shared utilities and helper functions
 
 pub mod account;
+pub mod acl;
+pub mod acl_impl;
 pub mod database;
 pub mod database_impl;
 pub mod subscription;

--- a/crates/redisctl/src/commands/cloud/utils.rs
+++ b/crates/redisctl/src/commands/cloud/utils.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use serde_json::Value;
+use std::io::{self, Write};
 use tabled::Tabled;
 
 #[cfg(unix)]
@@ -236,4 +237,15 @@ pub fn print_formatted_output(data: Value, output_format: OutputFormat) -> CliRe
         _ => {} // Table format handled by individual commands
     }
     Ok(())
+}
+
+/// Prompts the user for confirmation
+pub fn confirm_action(message: &str) -> CliResult<bool> {
+    print!("Are you sure you want to {}? [y/N]: ", message);
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    Ok(input.trim().eq_ignore_ascii_case("y") || input.trim().eq_ignore_ascii_case("yes"))
 }

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -404,5 +404,15 @@ async fn execute_cloud_command(
             )
             .await
         }
+        Acl(acl_cmd) => {
+            commands::cloud::acl::handle_acl_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                acl_cmd,
+                cli.output,
+                cli.query.as_deref(),
+            )
+            .await
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements Issue #118 - Add Cloud ACL management commands

## Changes

Added comprehensive ACL management commands for Redis Cloud API covering all three ACL resource types:

### Redis ACL Rules
- `cloud acl list-redis-rules` - List all Redis ACL rules
- `cloud acl create-redis-rule --name <name> --rule <rule>` - Create a new Redis ACL rule
- `cloud acl update-redis-rule <id> --name <name> --rule <rule>` - Update an existing Redis ACL rule
- `cloud acl delete-redis-rule <id> --force` - Delete a Redis ACL rule

### ACL Roles
- `cloud acl list-roles` - List all ACL roles
- `cloud acl create-role --name <name> --redis-rules <json|id>` - Create a new ACL role
- `cloud acl update-role <id> --name <name> --redis-rules <json|id>` - Update an existing ACL role
- `cloud acl delete-role <id> --force` - Delete an ACL role

### ACL Users
- `cloud acl list-acl-users` - List all ACL users
- `cloud acl get-acl-user <id>` - Get ACL user details
- `cloud acl create-acl-user --name <name> --role <role> --password <password>` - Create a new ACL user
- `cloud acl update-acl-user <id> --name <name> --role <role> --password <password>` - Update an ACL user
- `cloud acl delete-acl-user <id> --force` - Delete an ACL user

## Features
- All commands support multiple output formats (JSON, YAML, Table)
- JMESPath query filtering with `-q` flag
- Confirmation prompts for destructive operations (bypass with `--force`)
- Clear distinction between ACL users and account users
- Support for both JSON array and single ID input for redis-rules

## Testing
- ✅ Builds successfully
- ✅ All clippy checks pass with strict mode
- ✅ All existing tests pass
- ✅ Follows established patterns from other cloud commands

Closes #118