### PR TITLE
feat(cloud): implement cloud provider account commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -190,6 +190,41 @@ pub enum ProfileCommands {
     },
 }
 
+/// Cloud Provider Account Commands
+#[derive(Subcommand, Debug)]
+pub enum CloudProviderAccountCommands {
+    /// List all cloud provider accounts
+    List,
+    /// Get cloud provider account details
+    Get {
+        /// Cloud account ID
+        account_id: i32,
+    },
+    /// Create a new cloud provider account
+    Create {
+        /// JSON file containing the cloud account configuration
+        /// For GCP, this should be the service account JSON file
+        /// Use @filename to read from file
+        file: String,
+    },
+    /// Update a cloud provider account
+    Update {
+        /// Cloud account ID
+        account_id: i32,
+        /// JSON file containing updated cloud account configuration
+        /// Use @filename to read from file
+        file: String,
+    },
+    /// Delete a cloud provider account
+    Delete {
+        /// Cloud account ID
+        account_id: i32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
+}
+
 /// Cloud-specific commands (placeholder for now)
 #[derive(Subcommand, Debug)]
 pub enum CloudCommands {
@@ -212,6 +247,9 @@ pub enum CloudCommands {
     /// ACL (Access Control List) operations
     #[command(subcommand)]
     Acl(CloudAclCommands),
+    /// Cloud provider account operations
+    #[command(subcommand, name = "provider-account")]
+    ProviderAccount(CloudProviderAccountCommands),
 }
 
 /// Enterprise-specific commands (placeholder for now)

--- a/crates/redisctl/src/commands/cloud/cloud_account.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code)]
+
+use crate::cli::{CloudProviderAccountCommands, OutputFormat};
+use crate::commands::cloud::cloud_account_impl;
+use crate::commands::cloud::utils::create_cloud_client_raw;
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+
+pub async fn handle_cloud_account_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &CloudProviderAccountCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let profile = conn_mgr.get_profile(profile_name)?;
+    let client = create_cloud_client_raw(profile).await?;
+
+    match command {
+        CloudProviderAccountCommands::List => {
+            cloud_account_impl::handle_list(&client, output_format, query).await
+        }
+        CloudProviderAccountCommands::Get { account_id } => {
+            cloud_account_impl::handle_get(&client, *account_id, output_format, query).await
+        }
+        CloudProviderAccountCommands::Create { file } => {
+            cloud_account_impl::handle_create(&client, file, output_format, query).await
+        }
+        CloudProviderAccountCommands::Update { account_id, file } => {
+            cloud_account_impl::handle_update(&client, *account_id, file, output_format, query)
+                .await
+        }
+        CloudProviderAccountCommands::Delete { account_id, force } => {
+            cloud_account_impl::handle_delete(&client, *account_id, *force).await
+        }
+    }
+}

--- a/crates/redisctl/src/commands/cloud/cloud_account_impl.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account_impl.rs
@@ -1,0 +1,225 @@
+#![allow(dead_code)]
+
+use crate::cli::OutputFormat;
+use crate::commands::cloud::utils::{
+    confirm_action, handle_output, print_formatted_output, read_file_input,
+};
+use crate::error::Result as CliResult;
+
+use anyhow::Context;
+use comfy_table::{Cell, Color, Table};
+use redis_cloud::CloudClient;
+use serde_json::{Value, json};
+
+pub async fn handle_list(
+    client: &CloudClient,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let result = client
+        .get_raw("/cloud-accounts")
+        .await
+        .context("Failed to list cloud accounts")?;
+
+    // For table output, create a formatted table
+    if matches!(output_format, OutputFormat::Table)
+        && query.is_none()
+        && let Some(accounts) = result.get("cloudAccounts").and_then(|a| a.as_array())
+    {
+        let mut table = Table::new();
+        table.set_header(vec!["ID", "Name", "Provider", "Status", "Created"]);
+
+        for account in accounts {
+            let id = account.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
+            let name = account.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let provider = account
+                .get("provider")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let status = account.get("status").and_then(|v| v.as_str()).unwrap_or("");
+            let created_timestamp = account
+                .get("createdTimestamp")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            let status_cell = match status {
+                "active" => Cell::new(status).fg(Color::Green),
+                "inactive" => Cell::new(status).fg(Color::Red),
+                _ => Cell::new(status),
+            };
+
+            table.add_row(vec![
+                Cell::new(id),
+                Cell::new(name),
+                Cell::new(provider),
+                status_cell,
+                Cell::new(created_timestamp),
+            ]);
+        }
+
+        println!("{}", table);
+        return Ok(());
+    }
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn handle_get(
+    client: &CloudClient,
+    account_id: i32,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let result = client
+        .get_raw(&format!("/cloud-accounts/{}", account_id))
+        .await
+        .context("Failed to get cloud account")?;
+
+    // For table output, create a detailed view
+    if matches!(output_format, OutputFormat::Table) && query.is_none() {
+        let mut table = Table::new();
+        table.set_header(vec!["Field", "Value"]);
+
+        if let Some(obj) = result.as_object() {
+            for (key, value) in obj {
+                // Mask sensitive fields
+                let display_value =
+                    if key.contains("secret") || key.contains("password") || key.contains("key") {
+                        "***REDACTED***".to_string()
+                    } else {
+                        match value {
+                            Value::String(s) => s.clone(),
+                            _ => value.to_string(),
+                        }
+                    };
+                table.add_row(vec![Cell::new(key), Cell::new(display_value)]);
+            }
+        }
+
+        println!("{}", table);
+        return Ok(());
+    }
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn handle_create(
+    client: &CloudClient,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let content = read_file_input(file)?;
+    let mut payload: Value =
+        serde_json::from_str(&content).context("Failed to parse JSON from file")?;
+
+    // If the input is a GCP service account JSON, convert it to the cloud account format
+    if let Some(_project_id) = payload.get("project_id") {
+        // This is a GCP service account JSON
+        let provider_payload = json!({
+            "provider": "GCP",
+            "name": payload.get("client_email")
+                .and_then(|v| v.as_str())
+                .unwrap_or("GCP Cloud Account"),
+            "serviceAccountJson": serde_json::to_string(&payload)?
+        });
+        payload = provider_payload;
+    }
+
+    // Validate required fields based on provider
+    let provider = payload
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing 'provider' field in JSON"))?;
+
+    match provider {
+        "AWS" => {
+            if payload.get("accessKeyId").is_none() {
+                return Err(anyhow::anyhow!("AWS provider requires 'accessKeyId' field").into());
+            }
+            if payload.get("accessSecretKey").is_none() {
+                return Err(
+                    anyhow::anyhow!("AWS provider requires 'accessSecretKey' field").into(),
+                );
+            }
+        }
+        "GCP" => {
+            if payload.get("serviceAccountJson").is_none() {
+                return Err(
+                    anyhow::anyhow!("GCP provider requires 'serviceAccountJson' field").into(),
+                );
+            }
+        }
+        "Azure" => {
+            if payload.get("subscriptionId").is_none() {
+                return Err(
+                    anyhow::anyhow!("Azure provider requires 'subscriptionId' field").into(),
+                );
+            }
+            if payload.get("tenantId").is_none() {
+                return Err(anyhow::anyhow!("Azure provider requires 'tenantId' field").into());
+            }
+            if payload.get("clientId").is_none() {
+                return Err(anyhow::anyhow!("Azure provider requires 'clientId' field").into());
+            }
+            if payload.get("clientSecret").is_none() {
+                return Err(anyhow::anyhow!("Azure provider requires 'clientSecret' field").into());
+            }
+        }
+        _ => {
+            return Err(anyhow::anyhow!("Unknown provider: {}", provider).into());
+        }
+    }
+
+    let result = client
+        .post_raw("/cloud-accounts", payload)
+        .await
+        .context("Failed to create cloud account")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn handle_update(
+    client: &CloudClient,
+    account_id: i32,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let content = read_file_input(file)?;
+    let payload: Value =
+        serde_json::from_str(&content).context("Failed to parse JSON from file")?;
+
+    let result = client
+        .put_raw(&format!("/cloud-accounts/{}", account_id), payload)
+        .await
+        .context("Failed to update cloud account")?;
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+pub async fn handle_delete(client: &CloudClient, account_id: i32, force: bool) -> CliResult<()> {
+    if !force {
+        let confirmed = confirm_action(&format!("delete cloud account {}", account_id))?;
+        if !confirmed {
+            println!("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    client
+        .delete_raw(&format!("/cloud-accounts/{}", account_id))
+        .await
+        .context("Failed to delete cloud account")?;
+
+    println!("Cloud account {} deleted successfully", account_id);
+    Ok(())
+}

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -10,6 +10,8 @@
 pub mod account;
 pub mod acl;
 pub mod acl_impl;
+pub mod cloud_account;
+pub mod cloud_account_impl;
 pub mod database;
 pub mod database_impl;
 pub mod subscription;

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 pub enum RedisCtlError {
     #[error("Configuration error: {0}")]
     Config(String),
+    #[error("Configuration error: {0}")]
+    Configuration(String),
 
     #[error("Profile '{name}' not found")]
     ProfileNotFound { name: String },
@@ -39,6 +41,8 @@ pub enum RedisCtlError {
 
     #[error("Command not supported for deployment type '{deployment_type}'")]
     UnsupportedDeploymentType { deployment_type: String },
+    #[error("File error for '{path}': {message}")]
+    FileError { path: String, message: String },
 
     #[error("Connection error: {message}")]
     ConnectionError { message: String },

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -414,5 +414,15 @@ async fn execute_cloud_command(
             )
             .await
         }
+        ProviderAccount(provider_account_cmd) => {
+            commands::cloud::cloud_account::handle_cloud_account_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                provider_account_cmd,
+                cli.output,
+                cli.query.as_deref(),
+            )
+            .await
+        }
     }
 }


### PR DESCRIPTION
## Summary
Implements full CRUD operations for cloud provider accounts, closing #119.

## Features
- ✅ List all cloud provider accounts
- ✅ Get details of a specific account  
- ✅ Create new accounts (AWS, GCP, Azure)
- ✅ Update existing accounts
- ✅ Delete accounts with confirmation

## Implementation Details
- Support for all three major cloud providers (AWS, GCP, Azure)
- Automatic GCP service account JSON detection and conversion
- Provider-specific validation for required fields
- Sensitive field masking in table output (passwords, keys, secrets)
- File input support with @ prefix notation
- Multiple output formats (JSON, YAML, Table)
- JMESPath query filtering support

## Testing
- ✅ cargo build
- ✅ cargo clippy (no warnings)
- ✅ cargo test (all pass)

## Usage Examples
```bash
# List all cloud provider accounts
redisctl cloud provider-account list

# Create AWS account
redisctl cloud provider-account create @aws-account.json

# Create GCP account (auto-detects service account JSON)
redisctl cloud provider-account create @service-account.json

# Get account details (sensitive fields masked in table output)
redisctl cloud provider-account get 12345

# Update account
redisctl cloud provider-account update 12345 @updated-config.json

# Delete account
redisctl cloud provider-account delete 12345 --force
```

Closes #119