### PR TITLE
feat(cloud): implement task commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1556,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -2010,6 +2029,7 @@ dependencies = [
  "criterion",
  "dialoguer",
  "directories",
+ "indicatif",
  "jmespath",
  "pager",
  "predicates",

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -34,6 +34,7 @@ dialoguer = "0.11"
 colored = "2.1"
 tabled = { version = "0.17", features = ["ansi"] }
 terminal_size = "0.4"
+indicatif = "0.17"
 
 # Shared utility dependencies
 thiserror = { workspace = true }

--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -190,6 +190,38 @@ pub enum ProfileCommands {
     },
 }
 
+/// Cloud Task Commands
+#[derive(Subcommand, Debug)]
+pub enum CloudTaskCommands {
+    /// Get task status and details
+    Get {
+        /// Task ID (UUID format)
+        id: String,
+    },
+    /// Wait for task to complete
+    Wait {
+        /// Task ID (UUID format)
+        id: String,
+        /// Maximum time to wait in seconds
+        #[arg(long, default_value = "300")]
+        timeout: u64,
+        /// Polling interval in seconds
+        #[arg(long, default_value = "2")]
+        interval: u64,
+    },
+    /// Poll task status with live updates
+    Poll {
+        /// Task ID (UUID format)
+        id: String,
+        /// Polling interval in seconds
+        #[arg(long, default_value = "2")]
+        interval: u64,
+        /// Maximum number of polls (0 = unlimited)
+        #[arg(long, default_value = "0")]
+        max_polls: u64,
+    },
+}
+
 /// Cloud Provider Account Commands
 #[derive(Subcommand, Debug)]
 pub enum CloudProviderAccountCommands {
@@ -250,6 +282,9 @@ pub enum CloudCommands {
     /// Cloud provider account operations
     #[command(subcommand, name = "provider-account")]
     ProviderAccount(CloudProviderAccountCommands),
+    /// Task operations
+    #[command(subcommand)]
+    Task(CloudTaskCommands),
 }
 
 /// Enterprise-specific commands (placeholder for now)

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -16,6 +16,7 @@ pub mod database;
 pub mod database_impl;
 pub mod subscription;
 pub mod subscription_impl;
+pub mod task;
 pub mod user;
 pub mod utils;
 

--- a/crates/redisctl/src/commands/cloud/task.rs
+++ b/crates/redisctl/src/commands/cloud/task.rs
@@ -1,0 +1,383 @@
+//! Cloud task command implementations
+
+#![allow(dead_code)]
+
+use crate::cli::{CloudTaskCommands, OutputFormat};
+use crate::connection::ConnectionManager;
+use crate::error::{RedisCtlError, Result as CliResult};
+use crate::output::print_output;
+use anyhow::Context;
+use colored::Colorize;
+use indicatif::{ProgressBar, ProgressStyle};
+use redis_cloud::CloudClient;
+use serde_json::Value;
+use std::time::Duration;
+use tokio::time::{Instant, sleep};
+
+/// Handle cloud task commands
+pub async fn handle_task_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &CloudTaskCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    match command {
+        CloudTaskCommands::Get { id } => {
+            get_task(conn_mgr, profile_name, id, output_format, query).await
+        }
+        CloudTaskCommands::Wait {
+            id,
+            timeout,
+            interval,
+        } => {
+            wait_for_task(
+                conn_mgr,
+                profile_name,
+                id,
+                *timeout,
+                *interval,
+                output_format,
+            )
+            .await
+        }
+        CloudTaskCommands::Poll {
+            id,
+            interval,
+            max_polls,
+        } => {
+            poll_task(
+                conn_mgr,
+                profile_name,
+                id,
+                *interval,
+                *max_polls,
+                output_format,
+            )
+            .await
+        }
+    }
+}
+
+/// Get task status and details
+async fn get_task(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    task_id: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let task = fetch_task(&client, task_id).await?;
+
+    // Apply JMESPath query if provided
+    let data = if let Some(q) = query {
+        super::utils::apply_jmespath(&task, q)?
+    } else {
+        task
+    };
+
+    match output_format {
+        OutputFormat::Auto | OutputFormat::Table => {
+            print_task_details(&data)?;
+        }
+        OutputFormat::Json => {
+            print_output(data, crate::output::OutputFormat::Json, None).map_err(|e| {
+                RedisCtlError::OutputError {
+                    message: e.to_string(),
+                }
+            })?;
+        }
+        OutputFormat::Yaml => {
+            print_output(data, crate::output::OutputFormat::Yaml, None).map_err(|e| {
+                RedisCtlError::OutputError {
+                    message: e.to_string(),
+                }
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Wait for a task to complete
+async fn wait_for_task(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    task_id: &str,
+    timeout_secs: u64,
+    interval_secs: u64,
+    output_format: OutputFormat,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let start = Instant::now();
+    let timeout = Duration::from_secs(timeout_secs);
+    let interval = Duration::from_secs(interval_secs);
+
+    // Create progress bar
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.green} {msg} [{elapsed_precise}]")
+            .unwrap(),
+    );
+    pb.set_message(format!("Waiting for task {}", task_id));
+
+    loop {
+        let task = fetch_task(&client, task_id).await?;
+        let state = get_task_state(&task);
+
+        pb.set_message(format!("Task {}: {}", task_id, format_task_state(&state)));
+
+        if is_terminal_state(&state) {
+            pb.finish_with_message(format!("Task {}: {}", task_id, format_task_state(&state)));
+
+            match output_format {
+                OutputFormat::Auto | OutputFormat::Table => {
+                    print_task_details(&task)?;
+                }
+                OutputFormat::Json => {
+                    print_output(task, crate::output::OutputFormat::Json, None)?;
+                }
+                OutputFormat::Yaml => {
+                    print_output(task, crate::output::OutputFormat::Yaml, None)?;
+                }
+            }
+
+            return Ok(());
+        }
+
+        if start.elapsed() > timeout {
+            pb.finish_with_message(format!("Timeout waiting for task {}", task_id));
+            return Err(RedisCtlError::Timeout {
+                message: format!(
+                    "Task {} did not complete within {} seconds",
+                    task_id, timeout_secs
+                ),
+            });
+        }
+
+        sleep(interval).await;
+    }
+}
+
+/// Poll task status with live updates
+async fn poll_task(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    task_id: &str,
+    interval_secs: u64,
+    max_polls: u64,
+    output_format: OutputFormat,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let interval = Duration::from_secs(interval_secs);
+    let mut poll_count = 0u64;
+
+    println!(
+        "Polling task {} every {} seconds...",
+        task_id, interval_secs
+    );
+    println!("Press Ctrl+C to stop\n");
+
+    loop {
+        let task = fetch_task(&client, task_id).await?;
+        let state = get_task_state(&task);
+        let timestamp = chrono::Local::now().format("%H:%M:%S");
+
+        // Clear screen for table output in auto mode
+        if matches!(output_format, OutputFormat::Auto | OutputFormat::Table) {
+            // Move cursor up to overwrite previous output
+            if poll_count > 0 {
+                print!("\x1B[2K"); // Clear line
+                print!("\x1B[1A"); // Move up one line
+                print!("\x1B[2K"); // Clear line
+                print!("\r"); // Return to start of line
+            }
+
+            println!(
+                "[{}] Task {}: {}",
+                timestamp,
+                task_id,
+                format_task_state(&state)
+            );
+
+            if let Some(progress) = task.get("progress").and_then(|p| p.as_u64()) {
+                print_progress_bar(progress);
+            }
+        } else {
+            // For JSON/YAML, print the full output each time
+            match output_format {
+                OutputFormat::Json => {
+                    print_output(task.clone(), crate::output::OutputFormat::Json, None)?;
+                }
+                OutputFormat::Yaml => {
+                    print_output(task.clone(), crate::output::OutputFormat::Yaml, None)?;
+                }
+                _ => {} // Auto/Table already handled above
+            }
+        }
+
+        if is_terminal_state(&state) {
+            println!("\nTask completed with state: {}", format_task_state(&state));
+            break;
+        }
+
+        poll_count += 1;
+        if max_polls > 0 && poll_count >= max_polls {
+            println!("\nReached maximum poll count ({})", max_polls);
+            break;
+        }
+
+        sleep(interval).await;
+    }
+
+    Ok(())
+}
+
+/// Fetch task details from API
+async fn fetch_task(client: &CloudClient, task_id: &str) -> CliResult<Value> {
+    client
+        .get_raw(&format!("/tasks/{}", task_id))
+        .await
+        .with_context(|| format!("Failed to fetch task {}", task_id))
+        .map_err(|e| RedisCtlError::ApiError {
+            message: e.to_string(),
+        })
+}
+
+/// Extract task state from response
+fn get_task_state(task: &Value) -> String {
+    task.get("state")
+        .or_else(|| task.get("status"))
+        .and_then(|s| s.as_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// Check if task is in terminal state
+fn is_terminal_state(state: &str) -> bool {
+    matches!(
+        state.to_lowercase().as_str(),
+        "completed" | "failed" | "error" | "success" | "cancelled" | "aborted"
+    )
+}
+
+/// Format task state with color
+fn format_task_state(state: &str) -> String {
+    match state.to_lowercase().as_str() {
+        "processing" | "running" | "in_progress" => state.yellow().to_string(),
+        "completed" | "success" => state.green().to_string(),
+        "failed" | "error" => state.red().to_string(),
+        "cancelled" | "aborted" => state.dimmed().to_string(),
+        _ => state.to_string(),
+    }
+}
+
+/// Print task details in table format
+fn print_task_details(task: &Value) -> CliResult<()> {
+    use super::utils::DetailRow;
+    use tabled::{Table, settings::Style};
+
+    let mut rows = Vec::new();
+
+    // Task ID
+    if let Some(id) = task.get("taskId").or_else(|| task.get("id")) {
+        rows.push(DetailRow {
+            field: "Task ID".to_string(),
+            value: id.to_string().trim_matches('"').to_string(),
+        });
+    }
+
+    // State/Status
+    let state = get_task_state(task);
+    rows.push(DetailRow {
+        field: "State".to_string(),
+        value: format_task_state(&state),
+    });
+
+    // Progress
+    if let Some(progress) = task.get("progress").and_then(|p| p.as_u64()) {
+        rows.push(DetailRow {
+            field: "Progress".to_string(),
+            value: format!("{}%", progress),
+        });
+    }
+
+    // Description
+    if let Some(desc) = task.get("description").and_then(|d| d.as_str()) {
+        rows.push(DetailRow {
+            field: "Description".to_string(),
+            value: desc.to_string(),
+        });
+    }
+
+    // Resource info
+    if let Some(resource) = task.get("resourceId").and_then(|r| r.as_str()) {
+        rows.push(DetailRow {
+            field: "Resource ID".to_string(),
+            value: resource.to_string(),
+        });
+    }
+
+    if let Some(resource_type) = task.get("resourceType").and_then(|r| r.as_str()) {
+        rows.push(DetailRow {
+            field: "Resource Type".to_string(),
+            value: resource_type.to_string(),
+        });
+    }
+
+    // Timing
+    if let Some(created) = task.get("createdTimestamp").and_then(|t| t.as_str()) {
+        rows.push(DetailRow {
+            field: "Created".to_string(),
+            value: super::utils::format_date(created.to_string()),
+        });
+    }
+
+    if let Some(updated) = task.get("lastUpdatedTimestamp").and_then(|t| t.as_str()) {
+        rows.push(DetailRow {
+            field: "Last Updated".to_string(),
+            value: super::utils::format_date(updated.to_string()),
+        });
+    }
+
+    // Error details if failed
+    if matches!(state.to_lowercase().as_str(), "failed" | "error") {
+        if let Some(error) = task.get("error").and_then(|e| e.as_str()) {
+            rows.push(DetailRow {
+                field: "Error".to_string(),
+                value: error.red().to_string(),
+            });
+        }
+        if let Some(error_msg) = task.get("errorMessage").and_then(|e| e.as_str()) {
+            rows.push(DetailRow {
+                field: "Error Message".to_string(),
+                value: error_msg.red().to_string(),
+            });
+        }
+    }
+
+    if rows.is_empty() {
+        println!("No task information available");
+        return Ok(());
+    }
+
+    let mut table = Table::new(&rows);
+    table.with(Style::blank());
+
+    println!("{}", table);
+    Ok(())
+}
+
+/// Print a simple progress bar
+fn print_progress_bar(progress: u64) {
+    let width = 30;
+    let filled = (progress as usize * width) / 100;
+    let empty = width - filled;
+
+    print!("Progress: [");
+    print!("{}", "=".repeat(filled).green());
+    print!("{}", "-".repeat(empty).dimmed());
+    println!("] {}%", progress);
+}

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -47,6 +47,9 @@ pub enum RedisCtlError {
     #[error("Connection error: {message}")]
     ConnectionError { message: String },
 
+    #[error("Timeout: {message}")]
+    Timeout { message: String },
+
     #[error("Output formatting error: {message}")]
     OutputError { message: String },
 }

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -424,5 +424,15 @@ async fn execute_cloud_command(
             )
             .await
         }
+        Task(task_cmd) => {
+            commands::cloud::task::handle_task_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                task_cmd,
+                cli.output,
+                cli.query.as_deref(),
+            )
+            .await
+        }
     }
 }


### PR DESCRIPTION
## Summary
Implements task monitoring operations for asynchronous Redis Cloud tasks, closing #123.

## Features Added
- ✅ **Get task** - Retrieve status and details of a specific task
- ✅ **Wait for task** - Block until task completes (with timeout)
- ✅ **Poll task** - Live monitoring with configurable intervals

## Implementation Details

### Core Features
- Progress indicators using indicatif for wait/poll operations
- Terminal state detection (completed, failed, error, cancelled, aborted)
- Color-coded status display (yellow=running, green=success, red=error)
- Detailed error information for failed tasks
- Configurable timeouts and polling intervals

### CLI Enhancements
Beyond the basic API method, added two powerful CLI features:
- **Wait command**: Blocks with spinner until task completes or times out
- **Poll command**: Live status updates with progress bars and timestamps

## Testing
- ✅ cargo build (no errors)
- ✅ cargo clippy (no warnings)
- ✅ cargo test (all pass)

## Usage Examples
```bash
# Get task status
redisctl cloud task get "a1b2c3d4-e5f6-7890-abcd-ef1234567890"

# Wait for task to complete (default 5 min timeout)
redisctl cloud task wait "a1b2c3d4-e5f6-7890-abcd-ef1234567890"

# Wait with custom timeout and interval
redisctl cloud task wait "a1b2c3d4-e5f6-7890-abcd-ef1234567890" \
  --timeout 600 --interval 5

# Poll task status every 2 seconds
redisctl cloud task poll "a1b2c3d4-e5f6-7890-abcd-ef1234567890"

# Poll with custom interval and max attempts
redisctl cloud task poll "a1b2c3d4-e5f6-7890-abcd-ef1234567890" \
  --interval 5 --max-polls 60
```

## Display Examples
```
$ redisctl cloud task wait abc-123
⠙ Task abc-123: processing [00:00:12]
✓ Task abc-123: completed [00:00:15]

Task ID:     abc-123
State:       completed
Progress:    100%
Description: Creating database
Created:     2 minutes ago
```

## Note
Task IDs are typically returned from other operations (e.g., database creation). Consider future enhancement to add `--wait` flag to operations that return task IDs.

Closes #123