### PR TITLE
feat(cloud): implement VPC Peering connectivity commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -190,6 +190,119 @@ pub enum ProfileCommands {
     },
 }
 
+/// Cloud Connectivity Commands
+#[derive(Subcommand, Debug)]
+pub enum CloudConnectivityCommands {
+    /// VPC Peering operations
+    #[command(subcommand, name = "vpc-peering")]
+    VpcPeering(VpcPeeringCommands),
+    /// Private Service Connect operations
+    #[command(subcommand, name = "psc")]
+    Psc(PscCommands),
+    /// Transit Gateway operations
+    #[command(subcommand, name = "tgw")]
+    Tgw(TgwCommands),
+}
+
+/// VPC Peering Commands
+#[derive(Subcommand, Debug)]
+pub enum VpcPeeringCommands {
+    /// Get VPC peering details
+    Get {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+    },
+    /// Create VPC peering
+    Create {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Configuration JSON file or string (use @filename for file)
+        data: String,
+    },
+    /// Update VPC peering
+    Update {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Peering ID
+        #[arg(long)]
+        peering_id: i32,
+        /// Configuration JSON file or string (use @filename for file)
+        data: String,
+    },
+    /// Delete VPC peering
+    Delete {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Peering ID
+        #[arg(long)]
+        peering_id: i32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
+    /// List Active-Active VPC peerings
+    #[command(name = "list-aa")]
+    ListActiveActive {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+    },
+    /// Create Active-Active VPC peering
+    #[command(name = "create-aa")]
+    CreateActiveActive {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Configuration JSON file or string (use @filename for file)
+        data: String,
+    },
+    /// Update Active-Active VPC peering
+    #[command(name = "update-aa")]
+    UpdateActiveActive {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Peering ID
+        #[arg(long)]
+        peering_id: i32,
+        /// Configuration JSON file or string (use @filename for file)
+        data: String,
+    },
+    /// Delete Active-Active VPC peering
+    #[command(name = "delete-aa")]
+    DeleteActiveActive {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Peering ID
+        #[arg(long)]
+        peering_id: i32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+/// PSC Commands (placeholder)
+#[derive(Subcommand, Debug)]
+pub enum PscCommands {
+    /// Placeholder
+    #[command(hide = true)]
+    Placeholder,
+}
+
+/// TGW Commands (placeholder)
+#[derive(Subcommand, Debug)]
+pub enum TgwCommands {
+    /// Placeholder
+    #[command(hide = true)]
+    Placeholder,
+}
+
 /// Cloud Task Commands
 #[derive(Subcommand, Debug)]
 pub enum CloudTaskCommands {
@@ -285,6 +398,9 @@ pub enum CloudCommands {
     /// Task operations
     #[command(subcommand)]
     Task(CloudTaskCommands),
+    /// Network connectivity operations (VPC, PSC, TGW)
+    #[command(subcommand)]
+    Connectivity(CloudConnectivityCommands),
 }
 
 /// Enterprise-specific commands (placeholder for now)

--- a/crates/redisctl/src/commands/cloud/connectivity/mod.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/mod.rs
@@ -1,0 +1,39 @@
+//! Cloud connectivity command implementations
+
+#![allow(dead_code)]
+
+pub mod vpc_peering;
+
+use crate::cli::{CloudConnectivityCommands, OutputFormat};
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+
+/// Handle connectivity commands
+pub async fn handle_connectivity_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &CloudConnectivityCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    match command {
+        CloudConnectivityCommands::VpcPeering(vpc_cmd) => {
+            vpc_peering::handle_vpc_peering_command(
+                conn_mgr,
+                profile_name,
+                vpc_cmd,
+                output_format,
+                query,
+            )
+            .await
+        }
+        CloudConnectivityCommands::Psc(_) => {
+            eprintln!("PSC commands not yet implemented (Issue #177)");
+            Ok(())
+        }
+        CloudConnectivityCommands::Tgw(_) => {
+            eprintln!("Transit Gateway commands not yet implemented (Issue #178)");
+            Ok(())
+        }
+    }
+}

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -12,6 +12,7 @@ pub mod acl;
 pub mod acl_impl;
 pub mod cloud_account;
 pub mod cloud_account_impl;
+pub mod connectivity;
 pub mod database;
 pub mod database_impl;
 pub mod subscription;
@@ -23,6 +24,8 @@ pub mod utils;
 // Re-export all handler functions for backward compatibility
 #[allow(unused_imports)]
 pub use account::handle_account_command;
+#[allow(unused_imports)]
+pub use connectivity::handle_connectivity_command;
 #[allow(unused_imports)]
 pub use database::handle_database_command;
 #[allow(unused_imports)]

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -434,5 +434,15 @@ async fn execute_cloud_command(
             )
             .await
         }
+        Connectivity(connectivity_cmd) => {
+            commands::cloud::connectivity::handle_connectivity_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                connectivity_cmd,
+                cli.output,
+                cli.query.as_deref(),
+            )
+            .await
+        }
     }
 }


### PR DESCRIPTION
## Summary
Implements VPC Peering connectivity commands for Redis Cloud API.

This is **Part 1 of 3** for implementing full connectivity support (Issue #120).

## Changes
- Add 8 VPC Peering commands (4 standard, 4 Active-Active)
- Support get, create, update, delete operations for both types  
- Include task ID detection for async operations
- Add confirmation prompts for delete operations
- Implement table formatting for list views

## Commands Added
### Standard VPC Peering
- `redisctl cloud connectivity vpc-peering get`
- `redisctl cloud connectivity vpc-peering create`
- `redisctl cloud connectivity vpc-peering update`
- `redisctl cloud connectivity vpc-peering delete`

### Active-Active VPC Peering
- `redisctl cloud connectivity vpc-peering aa-list`
- `redisctl cloud connectivity vpc-peering aa-create`
- `redisctl cloud connectivity vpc-peering aa-update`
- `redisctl cloud connectivity vpc-peering aa-delete`

## Testing
- ✅ cargo build
- ✅ cargo clippy
- ✅ cargo test

## Related Issues
- Part of #120 (Network connectivity commands)
- Resolves #176 (VPC Peering specific)
- Related: #177 (PSC - Part 2), #178 (TGW - Part 3)