### PR TITLE
feat(cloud): implement Transit Gateway (TGW) commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -419,12 +419,148 @@ pub enum PscCommands {
     },
 }
 
-/// TGW Commands (placeholder)
+/// Transit Gateway (TGW) Commands
 #[derive(Subcommand, Debug)]
 pub enum TgwCommands {
-    /// Placeholder
-    #[command(hide = true)]
-    Placeholder,
+    // Standard TGW Attachment operations
+    /// List TGW attachments
+    #[command(name = "attachments-list")]
+    AttachmentsList {
+        /// Subscription ID
+        subscription_id: i32,
+    },
+    /// Create TGW attachment
+    #[command(name = "attachment-create")]
+    AttachmentCreate {
+        /// Subscription ID
+        subscription_id: i32,
+        /// JSON file with attachment configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Create TGW attachment with ID in path
+    #[command(name = "attachment-create-with-id")]
+    AttachmentCreateWithId {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Transit Gateway ID
+        tgw_id: String,
+    },
+    /// Update TGW attachment CIDRs
+    #[command(name = "attachment-update")]
+    AttachmentUpdate {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Attachment ID
+        attachment_id: String,
+        /// JSON file with CIDR configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Delete TGW attachment
+    #[command(name = "attachment-delete")]
+    AttachmentDelete {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Attachment ID
+        attachment_id: String,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
+    // Standard TGW Invitation operations
+    /// List TGW resource share invitations
+    #[command(name = "invitations-list")]
+    InvitationsList {
+        /// Subscription ID
+        subscription_id: i32,
+    },
+    /// Accept TGW resource share invitation
+    #[command(name = "invitation-accept")]
+    InvitationAccept {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Invitation ID
+        invitation_id: String,
+    },
+    /// Reject TGW resource share invitation
+    #[command(name = "invitation-reject")]
+    InvitationReject {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Invitation ID
+        invitation_id: String,
+    },
+
+    // Active-Active TGW Attachment operations
+    /// List Active-Active TGW attachments
+    #[command(name = "aa-attachments-list")]
+    AaAttachmentsList {
+        /// Subscription ID
+        subscription_id: i32,
+    },
+    /// Create Active-Active TGW attachment
+    #[command(name = "aa-attachment-create")]
+    AaAttachmentCreate {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Region ID
+        region_id: i32,
+        /// JSON file with attachment configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Update Active-Active TGW attachment CIDRs
+    #[command(name = "aa-attachment-update")]
+    AaAttachmentUpdate {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Region ID
+        region_id: i32,
+        /// Attachment ID
+        attachment_id: String,
+        /// JSON file with CIDR configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Delete Active-Active TGW attachment
+    #[command(name = "aa-attachment-delete")]
+    AaAttachmentDelete {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Region ID
+        region_id: i32,
+        /// Attachment ID
+        attachment_id: String,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
+    // Active-Active TGW Invitation operations
+    /// List Active-Active TGW resource share invitations
+    #[command(name = "aa-invitations-list")]
+    AaInvitationsList {
+        /// Subscription ID
+        subscription_id: i32,
+    },
+    /// Accept Active-Active TGW resource share invitation
+    #[command(name = "aa-invitation-accept")]
+    AaInvitationAccept {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Region ID
+        region_id: i32,
+        /// Invitation ID
+        invitation_id: String,
+    },
+    /// Reject Active-Active TGW resource share invitation
+    #[command(name = "aa-invitation-reject")]
+    AaInvitationReject {
+        /// Subscription ID
+        subscription_id: i32,
+        /// Region ID
+        region_id: i32,
+        /// Invitation ID
+        invitation_id: String,
+    },
 }
 
 /// Cloud Task Commands

--- a/crates/redisctl/src/commands/cloud/connectivity/mod.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/mod.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 pub mod psc;
+pub mod tgw;
 pub mod vpc_peering;
 
 use crate::cli::{CloudConnectivityCommands, OutputFormat};
@@ -31,9 +32,8 @@ pub async fn handle_connectivity_command(
         CloudConnectivityCommands::Psc(psc_cmd) => {
             psc::handle_psc_command(conn_mgr, profile_name, psc_cmd, output_format, query).await
         }
-        CloudConnectivityCommands::Tgw(_) => {
-            eprintln!("Transit Gateway commands not yet implemented (Issue #178)");
-            Ok(())
+        CloudConnectivityCommands::Tgw(tgw_cmd) => {
+            tgw::handle_tgw_command(conn_mgr, profile_name, tgw_cmd, output_format, query).await
         }
     }
 }

--- a/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
@@ -1,0 +1,574 @@
+//! Transit Gateway (TGW) command implementations
+
+#![allow(dead_code)]
+
+use crate::cli::{OutputFormat, TgwCommands};
+use crate::commands::cloud::utils::{
+    confirm_action, handle_output, print_formatted_output, read_file_input,
+};
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+use anyhow::Context;
+use redis_cloud::CloudClient;
+use redis_cloud::connectivity::transit_gateway::{TgwAttachmentRequest, TransitGatewayHandler};
+
+/// Handle TGW commands
+pub async fn handle_tgw_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &TgwCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr
+        .create_cloud_client(profile_name)
+        .await
+        .context("Failed to create Cloud client")?;
+
+    match command {
+        // Standard TGW operations
+        TgwCommands::AttachmentsList { subscription_id } => {
+            list_attachments(&client, *subscription_id, output_format, query).await
+        }
+        TgwCommands::AttachmentCreate {
+            subscription_id,
+            file,
+        } => create_attachment(&client, *subscription_id, file, output_format, query).await,
+        TgwCommands::AttachmentCreateWithId {
+            subscription_id,
+            tgw_id,
+        } => {
+            create_attachment_with_id(&client, *subscription_id, tgw_id, output_format, query).await
+        }
+        TgwCommands::AttachmentUpdate {
+            subscription_id,
+            attachment_id,
+            file,
+        } => {
+            update_attachment_cidrs(
+                &client,
+                *subscription_id,
+                attachment_id,
+                file,
+                output_format,
+                query,
+            )
+            .await
+        }
+        TgwCommands::AttachmentDelete {
+            subscription_id,
+            attachment_id,
+            yes,
+        } => delete_attachment(&client, *subscription_id, attachment_id, *yes).await,
+        TgwCommands::InvitationsList { subscription_id } => {
+            list_invitations(&client, *subscription_id, output_format, query).await
+        }
+        TgwCommands::InvitationAccept {
+            subscription_id,
+            invitation_id,
+        } => {
+            accept_invitation(
+                &client,
+                *subscription_id,
+                invitation_id,
+                output_format,
+                query,
+            )
+            .await
+        }
+        TgwCommands::InvitationReject {
+            subscription_id,
+            invitation_id,
+        } => {
+            reject_invitation(
+                &client,
+                *subscription_id,
+                invitation_id,
+                output_format,
+                query,
+            )
+            .await
+        }
+
+        // Active-Active TGW operations
+        TgwCommands::AaAttachmentsList { subscription_id } => {
+            list_attachments_aa(&client, *subscription_id, output_format, query).await
+        }
+        TgwCommands::AaAttachmentCreate {
+            subscription_id,
+            region_id,
+            file,
+        } => {
+            create_attachment_aa(
+                &client,
+                *subscription_id,
+                *region_id,
+                file,
+                output_format,
+                query,
+            )
+            .await
+        }
+        TgwCommands::AaAttachmentUpdate {
+            subscription_id,
+            region_id,
+            attachment_id,
+            file,
+        } => {
+            update_attachment_cidrs_aa(
+                &client,
+                *subscription_id,
+                *region_id,
+                attachment_id,
+                file,
+                output_format,
+                query,
+            )
+            .await
+        }
+        TgwCommands::AaAttachmentDelete {
+            subscription_id,
+            region_id,
+            attachment_id,
+            yes,
+        } => delete_attachment_aa(&client, *subscription_id, *region_id, attachment_id, *yes).await,
+        TgwCommands::AaInvitationsList { subscription_id } => {
+            list_invitations_aa(&client, *subscription_id, output_format, query).await
+        }
+        TgwCommands::AaInvitationAccept {
+            subscription_id,
+            region_id,
+            invitation_id,
+        } => {
+            accept_invitation_aa(
+                &client,
+                *subscription_id,
+                *region_id,
+                invitation_id,
+                output_format,
+                query,
+            )
+            .await
+        }
+        TgwCommands::AaInvitationReject {
+            subscription_id,
+            region_id,
+            invitation_id,
+        } => {
+            reject_invitation_aa(
+                &client,
+                *subscription_id,
+                *region_id,
+                invitation_id,
+                output_format,
+                query,
+            )
+            .await
+        }
+    }
+}
+
+// ============================================================================
+// Standard TGW Operations
+// ============================================================================
+
+async fn list_attachments(
+    client: &CloudClient,
+    subscription_id: i32,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .get_attachments(subscription_id)
+        .await
+        .context("Failed to get TGW attachments")?;
+
+    let json_response = serde_json::to_value(response).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn create_attachment(
+    client: &CloudClient,
+    subscription_id: i32,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let json_string = read_file_input(file)?;
+    let request: TgwAttachmentRequest =
+        serde_json::from_str(&json_string).context("Invalid TGW attachment configuration")?;
+
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .create_attachment(subscription_id, &request)
+        .await
+        .context("Failed to create TGW attachment")?;
+
+    // Convert response to JSON and check for task ID
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    if let Some(task_id) = json_response.get("taskId").and_then(|v| v.as_str()) {
+        eprintln!("TGW attachment creation initiated. Task ID: {}", task_id);
+        eprintln!(
+            "Use 'redisctl cloud task wait {}' to monitor progress",
+            task_id
+        );
+    }
+
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn create_attachment_with_id(
+    client: &CloudClient,
+    subscription_id: i32,
+    tgw_id: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .create_attachment_with_id(subscription_id, tgw_id)
+        .await
+        .context("Failed to create TGW attachment")?;
+
+    // Convert response to JSON and check for task ID
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    if let Some(task_id) = json_response.get("taskId").and_then(|v| v.as_str()) {
+        eprintln!("TGW attachment creation initiated. Task ID: {}", task_id);
+        eprintln!(
+            "Use 'redisctl cloud task wait {}' to monitor progress",
+            task_id
+        );
+    }
+
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn update_attachment_cidrs(
+    client: &CloudClient,
+    subscription_id: i32,
+    attachment_id: &str,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let json_string = read_file_input(file)?;
+    let request: TgwAttachmentRequest = serde_json::from_str(&json_string)
+        .context("Invalid TGW attachment update configuration")?;
+
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .update_attachment_cidrs(subscription_id, attachment_id.to_string(), &request)
+        .await
+        .context("Failed to update TGW attachment CIDRs")?;
+
+    // Convert response to JSON and check for task ID
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    if let Some(task_id) = json_response.get("taskId").and_then(|v| v.as_str()) {
+        eprintln!("TGW attachment update initiated. Task ID: {}", task_id);
+        eprintln!(
+            "Use 'redisctl cloud task wait {}' to monitor progress",
+            task_id
+        );
+    }
+
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn delete_attachment(
+    client: &CloudClient,
+    subscription_id: i32,
+    attachment_id: &str,
+    yes: bool,
+) -> CliResult<()> {
+    if !yes {
+        let prompt = format!(
+            "Delete TGW attachment {} for subscription {}?",
+            attachment_id, subscription_id
+        );
+        if !confirm_action(&prompt)? {
+            eprintln!("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    let handler = TransitGatewayHandler::new(client.clone());
+    handler
+        .delete_attachment(subscription_id, attachment_id.to_string())
+        .await
+        .context("Failed to delete TGW attachment")?;
+
+    eprintln!("TGW attachment deleted successfully");
+    Ok(())
+}
+
+async fn list_invitations(
+    client: &CloudClient,
+    subscription_id: i32,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .get_shared_invitations(subscription_id)
+        .await
+        .context("Failed to get TGW invitations")?;
+
+    let json_response = serde_json::to_value(response).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn accept_invitation(
+    client: &CloudClient,
+    subscription_id: i32,
+    invitation_id: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .accept_resource_share(subscription_id, invitation_id.to_string())
+        .await
+        .context("Failed to accept TGW invitation")?;
+
+    // Convert response to JSON and check for task ID
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    if let Some(task_id) = json_response.get("taskId").and_then(|v| v.as_str()) {
+        eprintln!("TGW invitation acceptance initiated. Task ID: {}", task_id);
+        eprintln!(
+            "Use 'redisctl cloud task wait {}' to monitor progress",
+            task_id
+        );
+    }
+
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn reject_invitation(
+    client: &CloudClient,
+    subscription_id: i32,
+    invitation_id: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .reject_resource_share(subscription_id, invitation_id.to_string())
+        .await
+        .context("Failed to reject TGW invitation")?;
+
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+// ============================================================================
+// Active-Active TGW Operations
+// ============================================================================
+
+async fn list_attachments_aa(
+    client: &CloudClient,
+    subscription_id: i32,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .get_attachments_active_active(subscription_id)
+        .await
+        .context("Failed to get Active-Active TGW attachments")?;
+
+    let json_response = serde_json::to_value(response).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn create_attachment_aa(
+    client: &CloudClient,
+    subscription_id: i32,
+    region_id: i32,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let json_string = read_file_input(file)?;
+    let request: TgwAttachmentRequest = serde_json::from_str(&json_string)
+        .context("Invalid Active-Active TGW attachment configuration")?;
+
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .create_attachment_active_active(subscription_id, region_id, &request)
+        .await
+        .context("Failed to create Active-Active TGW attachment")?;
+
+    // Convert response to JSON and check for task ID
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    if let Some(task_id) = json_response.get("taskId").and_then(|v| v.as_str()) {
+        eprintln!(
+            "Active-Active TGW attachment creation initiated. Task ID: {}",
+            task_id
+        );
+        eprintln!(
+            "Use 'redisctl cloud task wait {}' to monitor progress",
+            task_id
+        );
+    }
+
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn update_attachment_cidrs_aa(
+    client: &CloudClient,
+    subscription_id: i32,
+    region_id: i32,
+    attachment_id: &str,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let json_string = read_file_input(file)?;
+    let request: TgwAttachmentRequest = serde_json::from_str(&json_string)
+        .context("Invalid Active-Active TGW attachment update configuration")?;
+
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .update_attachment_cidrs_active_active(
+            subscription_id,
+            region_id,
+            attachment_id.to_string(),
+            &request,
+        )
+        .await
+        .context("Failed to update Active-Active TGW attachment CIDRs")?;
+
+    // Convert response to JSON and check for task ID
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    if let Some(task_id) = json_response.get("taskId").and_then(|v| v.as_str()) {
+        eprintln!(
+            "Active-Active TGW attachment update initiated. Task ID: {}",
+            task_id
+        );
+        eprintln!(
+            "Use 'redisctl cloud task wait {}' to monitor progress",
+            task_id
+        );
+    }
+
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn delete_attachment_aa(
+    client: &CloudClient,
+    subscription_id: i32,
+    region_id: i32,
+    attachment_id: &str,
+    yes: bool,
+) -> CliResult<()> {
+    if !yes {
+        let prompt = format!(
+            "Delete Active-Active TGW attachment {} in region {} for subscription {}?",
+            attachment_id, region_id, subscription_id
+        );
+        if !confirm_action(&prompt)? {
+            eprintln!("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    let handler = TransitGatewayHandler::new(client.clone());
+    handler
+        .delete_attachment_active_active(subscription_id, region_id, attachment_id.to_string())
+        .await
+        .context("Failed to delete Active-Active TGW attachment")?;
+
+    eprintln!("Active-Active TGW attachment deleted successfully");
+    Ok(())
+}
+
+async fn list_invitations_aa(
+    client: &CloudClient,
+    subscription_id: i32,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .get_shared_invitations_active_active(subscription_id)
+        .await
+        .context("Failed to get Active-Active TGW invitations")?;
+
+    let json_response = serde_json::to_value(response).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn accept_invitation_aa(
+    client: &CloudClient,
+    subscription_id: i32,
+    region_id: i32,
+    invitation_id: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .accept_resource_share_active_active(subscription_id, region_id, invitation_id.to_string())
+        .await
+        .context("Failed to accept Active-Active TGW invitation")?;
+
+    // Convert response to JSON and check for task ID
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    if let Some(task_id) = json_response.get("taskId").and_then(|v| v.as_str()) {
+        eprintln!(
+            "Active-Active TGW invitation acceptance initiated. Task ID: {}",
+            task_id
+        );
+        eprintln!(
+            "Use 'redisctl cloud task wait {}' to monitor progress",
+            task_id
+        );
+    }
+
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+async fn reject_invitation_aa(
+    client: &CloudClient,
+    subscription_id: i32,
+    region_id: i32,
+    invitation_id: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let handler = TransitGatewayHandler::new(client.clone());
+    let response = handler
+        .reject_resource_share_active_active(subscription_id, region_id, invitation_id.to_string())
+        .await
+        .context("Failed to reject Active-Active TGW invitation")?;
+
+    let json_response = serde_json::to_value(&response).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Implements Transit Gateway (TGW) connectivity commands for AWS hub-and-spoke network topologies.

This is **Part 3 of 3** for implementing full connectivity support (Issue #120).

## Changes
- Add 15 TGW commands (8 standard, 7 Active-Active)
- Support attachment CRUD operations and resource share invitations
- Include support for AWS Transit Gateway hub-and-spoke topologies
- Add task ID detection for async operations
- Include confirmation prompts for delete operations

## Commands Added
### Standard TGW Operations
- `redisctl cloud connectivity tgw attachments-list`
- `redisctl cloud connectivity tgw attachment-create`
- `redisctl cloud connectivity tgw attachment-create-with-id`
- `redisctl cloud connectivity tgw attachment-update`
- `redisctl cloud connectivity tgw attachment-delete`
- `redisctl cloud connectivity tgw invitations-list`
- `redisctl cloud connectivity tgw invitation-accept`
- `redisctl cloud connectivity tgw invitation-reject`

### Active-Active TGW Operations
- `redisctl cloud connectivity tgw aa-attachments-list`
- `redisctl cloud connectivity tgw aa-attachment-create`
- `redisctl cloud connectivity tgw aa-attachment-update`
- `redisctl cloud connectivity tgw aa-attachment-delete`
- `redisctl cloud connectivity tgw aa-invitations-list`
- `redisctl cloud connectivity tgw aa-invitation-accept`
- `redisctl cloud connectivity tgw aa-invitation-reject`

## Testing
- ✅ cargo build
- ✅ cargo clippy
- ✅ cargo test

## Related Issues
- Completes #120 (Network connectivity commands)
- Resolves #178 (TGW specific)
- Related: #176 (VPC - Part 1), #177 (PSC - Part 2)

## Notes
This PR is stacked on top of the VPC (#179) and PSC (#187) PRs. Once all three are merged, we will have complete connectivity command coverage for Redis Cloud.