### PR TITLE
feat(cloud): implement fixed database commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -335,6 +335,126 @@ pub enum CloudTaskCommands {
     },
 }
 
+/// Cloud Fixed Database Commands
+#[derive(Subcommand, Debug)]
+pub enum CloudFixedDatabaseCommands {
+    /// List all databases in a fixed subscription
+    List {
+        /// Subscription ID
+        subscription_id: i32,
+    },
+    /// Get details of a specific fixed database
+    Get {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+    },
+    /// Create a new database in a fixed subscription
+    Create {
+        /// Subscription ID
+        subscription_id: i32,
+        /// JSON file with database configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Update fixed database configuration
+    Update {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// JSON file with update configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Delete a fixed database
+    Delete {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+    /// Get backup status for fixed database
+    #[command(name = "backup-status")]
+    BackupStatus {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+    },
+    /// Trigger manual backup
+    Backup {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+    },
+    /// Get import status
+    #[command(name = "import-status")]
+    ImportStatus {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+    },
+    /// Import data into fixed database
+    Import {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// JSON file with import configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// View slow query log
+    #[command(name = "slow-log")]
+    SlowLog {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// Maximum number of entries to return
+        #[arg(long)]
+        limit: Option<i32>,
+        /// Number of entries to skip
+        #[arg(long)]
+        offset: Option<i32>,
+    },
+    /// List tags for fixed database
+    #[command(name = "list-tags")]
+    ListTags {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+    },
+    /// Add a tag
+    #[command(name = "add-tag")]
+    AddTag {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// Tag key
+        #[arg(long)]
+        key: String,
+        /// Tag value
+        #[arg(long)]
+        value: String,
+    },
+    /// Update all tags
+    #[command(name = "update-tags")]
+    UpdateTags {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// JSON file with tags (use @filename or - for stdin)
+        file: String,
+    },
+    /// Update specific tag
+    #[command(name = "update-tag")]
+    UpdateTag {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// Tag key
+        #[arg(long)]
+        key: String,
+        /// Tag value
+        #[arg(long)]
+        value: String,
+    },
+    /// Delete a tag
+    #[command(name = "delete-tag")]
+    DeleteTag {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// Tag key
+        #[arg(long)]
+        key: String,
+    },
+}
+
 /// Cloud Provider Account Commands
 #[derive(Subcommand, Debug)]
 pub enum CloudProviderAccountCommands {
@@ -401,6 +521,9 @@ pub enum CloudCommands {
     /// Network connectivity operations (VPC, PSC, TGW)
     #[command(subcommand)]
     Connectivity(CloudConnectivityCommands),
+    /// Fixed database operations
+    #[command(subcommand, name = "fixed-database")]
+    FixedDatabase(CloudFixedDatabaseCommands),
 }
 
 /// Enterprise-specific commands (placeholder for now)

--- a/crates/redisctl/src/commands/cloud/fixed_database.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_database.rs
@@ -1,0 +1,401 @@
+//! Fixed database command implementations
+
+#![allow(dead_code)]
+
+use crate::cli::{CloudFixedDatabaseCommands, OutputFormat};
+use crate::commands::cloud::utils::{
+    confirm_action, handle_output, print_formatted_output, read_file_input,
+};
+use crate::connection::ConnectionManager;
+use crate::error::{RedisCtlError, Result as CliResult};
+use anyhow::Context;
+use redis_cloud::fixed::databases::{
+    DatabaseTagCreateRequest, DatabaseTagUpdateRequest, FixedDatabaseBackupRequest,
+    FixedDatabaseCreateRequest, FixedDatabaseHandler, FixedDatabaseImportRequest,
+    FixedDatabaseUpdateRequest,
+};
+
+/// Parse database ID in format "subscription_id:database_id"
+fn parse_fixed_database_id(id: &str) -> CliResult<(i32, i32)> {
+    let parts: Vec<&str> = id.split(':').collect();
+    if parts.len() != 2 {
+        return Err(RedisCtlError::InvalidInput {
+            message: format!(
+                "Invalid database ID format: {}. Expected format: subscription_id:database_id",
+                id
+            ),
+        });
+    }
+
+    let subscription_id = parts[0]
+        .parse::<i32>()
+        .with_context(|| format!("Invalid subscription ID: {}", parts[0]))?;
+    let database_id = parts[1]
+        .parse::<i32>()
+        .with_context(|| format!("Invalid database ID: {}", parts[1]))?;
+
+    Ok((subscription_id, database_id))
+}
+
+/// Handle fixed database commands
+pub async fn handle_fixed_database_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &CloudFixedDatabaseCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr
+        .create_cloud_client(profile_name)
+        .await
+        .context("Failed to create Cloud client")?;
+
+    let handler = FixedDatabaseHandler::new(client);
+
+    match command {
+        CloudFixedDatabaseCommands::List { subscription_id } => {
+            let databases = handler
+                .list(*subscription_id, None, None)
+                .await
+                .context("Failed to list fixed databases")?;
+
+            let json_response =
+                serde_json::to_value(databases).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::Get { id } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let database = handler
+                .get_by_id(subscription_id, database_id)
+                .await
+                .context("Failed to get fixed database")?;
+
+            let json_response =
+                serde_json::to_value(database).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::Create {
+            subscription_id,
+            file,
+        } => {
+            let json_string = read_file_input(file)?;
+            let request: FixedDatabaseCreateRequest =
+                serde_json::from_str(&json_string).context("Invalid database configuration")?;
+
+            let result = handler
+                .create(*subscription_id, &request)
+                .await
+                .context("Failed to create fixed database")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!("Fixed database creation initiated. Task ID: {}", task_id);
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::Update { id, file } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let json_string = read_file_input(file)?;
+            let request: FixedDatabaseUpdateRequest =
+                serde_json::from_str(&json_string).context("Invalid update configuration")?;
+
+            let result = handler
+                .update(subscription_id, database_id, &request)
+                .await
+                .context("Failed to update fixed database")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!("Fixed database update initiated. Task ID: {}", task_id);
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::Delete { id, yes } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+
+            if !yes {
+                let prompt = format!("Delete fixed database {}:{}?", subscription_id, database_id);
+                if !confirm_action(&prompt)? {
+                    eprintln!("Operation cancelled");
+                    return Ok(());
+                }
+            }
+
+            let result = handler
+                .delete_by_id(subscription_id, database_id)
+                .await
+                .context("Failed to delete fixed database")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!("Fixed database deletion initiated. Task ID: {}", task_id);
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            } else {
+                eprintln!("Fixed database deleted successfully");
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::BackupStatus { id } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let status = handler
+                .get_backup_status(subscription_id, database_id)
+                .await
+                .context("Failed to get backup status")?;
+
+            let json_response =
+                serde_json::to_value(status).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::Backup { id } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+
+            // Create a minimal backup request - most fields are optional
+            let backup_request = FixedDatabaseBackupRequest {
+                subscription_id: Some(subscription_id),
+                database_id: Some(database_id),
+                adhoc_backup_path: None,
+                command_type: None,
+                extra: serde_json::Value::Null,
+            };
+
+            let result = handler
+                .backup(subscription_id, database_id, &backup_request)
+                .await
+                .context("Failed to initiate backup")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!("Backup initiated. Task ID: {}", task_id);
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::ImportStatus { id } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let status = handler
+                .get_import_status(subscription_id, database_id)
+                .await
+                .context("Failed to get import status")?;
+
+            let json_response =
+                serde_json::to_value(status).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::Import { id, file } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let json_string = read_file_input(file)?;
+            let request: FixedDatabaseImportRequest =
+                serde_json::from_str(&json_string).context("Invalid import configuration")?;
+
+            let result = handler
+                .import(subscription_id, database_id, &request)
+                .await
+                .context("Failed to initiate import")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!("Import initiated. Task ID: {}", task_id);
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::SlowLog {
+            id,
+            limit: _,
+            offset: _,
+        } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            // Note: The API doesn't currently support limit/offset parameters
+            let result = handler
+                .get_slow_log(subscription_id, database_id)
+                .await
+                .context("Failed to get slow log")?;
+
+            let json_result =
+                serde_json::to_value(result).context("Failed to serialize response")?;
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::ListTags { id } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let tags = handler
+                .get_tags(subscription_id, database_id)
+                .await
+                .context("Failed to get tags")?;
+
+            let json_response =
+                serde_json::to_value(tags).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::AddTag { id, key, value } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let tag_request = DatabaseTagCreateRequest {
+                subscription_id: Some(subscription_id),
+                database_id: Some(database_id),
+                command_type: None,
+                key: key.clone(),
+                value: value.clone(),
+                extra: serde_json::Value::Null,
+            };
+
+            let result = handler
+                .create_tag(subscription_id, database_id, &tag_request)
+                .await
+                .context("Failed to add tag")?;
+
+            let json_result =
+                serde_json::to_value(result).context("Failed to serialize response")?;
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::UpdateTags { id, file } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let json_string = read_file_input(file)?;
+
+            // Parse the JSON directly into the expected format
+            let parsed: serde_json::Value =
+                serde_json::from_str(&json_string).context("Invalid tags configuration")?;
+
+            // Extract tags array or create from object
+            let tags_vec = if let Some(tags_array) = parsed.get("tags").and_then(|v| v.as_array()) {
+                tags_array.clone()
+            } else if parsed.is_object() {
+                // If it's just an object, wrap it in an array
+                vec![parsed]
+            } else {
+                return Err(
+                    anyhow::anyhow!("Invalid tags format. Expected object or array.").into(),
+                );
+            };
+
+            // Build the request with the proper structure
+            let tags_request = serde_json::json!({
+                "subscription_id": subscription_id,
+                "database_id": database_id,
+                "tags": tags_vec
+            });
+
+            // Use raw API call since the types don't match exactly
+            let client = conn_mgr
+                .create_cloud_client(profile_name)
+                .await
+                .context("Failed to create Cloud client")?;
+
+            let result = client
+                .put_raw(
+                    &format!(
+                        "/fixed/subscriptions/{}/databases/{}/tags",
+                        subscription_id, database_id
+                    ),
+                    tags_request,
+                )
+                .await
+                .context("Failed to update tags")?;
+
+            let data = handle_output(result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::UpdateTag { id, key, value } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+            let tag_request = DatabaseTagUpdateRequest {
+                subscription_id: Some(subscription_id),
+                database_id: Some(database_id),
+                command_type: None,
+                key: Some(key.clone()),
+                value: value.clone(),
+                extra: serde_json::Value::Null,
+            };
+
+            let result = handler
+                .update_tag(subscription_id, database_id, key.clone(), &tag_request)
+                .await
+                .context("Failed to update tag")?;
+
+            let json_result =
+                serde_json::to_value(result).context("Failed to serialize response")?;
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedDatabaseCommands::DeleteTag { id, key } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+
+            let _result = handler
+                .delete_tag(subscription_id, database_id, key.clone())
+                .await
+                .context("Failed to delete tag")?;
+
+            eprintln!("Tag '{}' deleted successfully", key);
+            Ok(())
+        }
+    }
+}

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -15,6 +15,7 @@ pub mod cloud_account_impl;
 pub mod connectivity;
 pub mod database;
 pub mod database_impl;
+pub mod fixed_database;
 pub mod subscription;
 pub mod subscription_impl;
 pub mod task;

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -444,5 +444,15 @@ async fn execute_cloud_command(
             )
             .await
         }
+        FixedDatabase(fixed_db_cmd) => {
+            commands::cloud::fixed_database::handle_fixed_database_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                fixed_db_cmd,
+                cli.output,
+                cli.query.as_deref(),
+            )
+            .await
+        }
     }
 }


### PR DESCRIPTION
## Summary
Implements fixed database commands for managing databases in fixed subscriptions with predetermined resources and pricing.

## Changes
- Add 15 fixed database commands covering all major operations
- Support CRUD operations for fixed databases
- Add backup and import functionality with status monitoring
- Include slow log viewing capability
- Implement comprehensive tag management (list, add, update, delete)
- Handle async operations with task ID feedback for user monitoring
- Include confirmation prompts for destructive operations
- Parse database IDs in `subscription:database` format for consistency

## Commands Added
### Core Operations
- `redisctl cloud fixed-database list --subscription ID`
- `redisctl cloud fixed-database get ID`
- `redisctl cloud fixed-database create --subscription ID @config.json`
- `redisctl cloud fixed-database update ID @update.json`
- `redisctl cloud fixed-database delete ID`

### Backup Operations  
- `redisctl cloud fixed-database backup-status ID`
- `redisctl cloud fixed-database backup ID`

### Import Operations
- `redisctl cloud fixed-database import-status ID`
- `redisctl cloud fixed-database import ID @import.json`

### Performance & Monitoring
- `redisctl cloud fixed-database slow-log ID`

### Tag Management
- `redisctl cloud fixed-database list-tags ID`
- `redisctl cloud fixed-database add-tag ID --key KEY --value VALUE`
- `redisctl cloud fixed-database update-tags ID @tags.json`
- `redisctl cloud fixed-database update-tag ID --key KEY --value VALUE`
- `redisctl cloud fixed-database delete-tag ID --key KEY`

## Testing
- ✅ cargo build
- ✅ cargo clippy
- ✅ cargo test

## Notes
- Fixed databases are part of fixed plans/subscriptions with predetermined resources
- Database ID format uses `subscription:database` notation for consistency
- The slow-log command currently doesn't support limit/offset parameters (API limitation)
- Tag update operations use raw API calls for complex nested structures

Resolves #121