### PR TITLE
feat(cloud): implement fixed subscription commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -715,6 +715,65 @@ pub enum CloudFixedDatabaseCommands {
     },
 }
 
+/// Cloud Fixed Subscription Commands
+#[derive(Subcommand, Debug)]
+pub enum CloudFixedSubscriptionCommands {
+    /// List all available fixed subscription plans
+    #[command(name = "list-plans")]
+    ListPlans {
+        /// Filter by cloud provider (AWS, GCP, Azure)
+        #[arg(long)]
+        provider: Option<String>,
+    },
+    /// Get plans for a specific subscription
+    #[command(name = "get-plans")]
+    GetPlans {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+    },
+    /// Get details of a specific plan
+    #[command(name = "get-plan")]
+    GetPlan {
+        /// Plan ID
+        id: i32,
+    },
+    /// List all fixed subscriptions
+    List,
+    /// Get details of a fixed subscription
+    Get {
+        /// Subscription ID
+        id: i32,
+    },
+    /// Create a new fixed subscription
+    Create {
+        /// JSON file with subscription configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Update fixed subscription
+    Update {
+        /// Subscription ID
+        id: i32,
+        /// JSON file with update configuration (use @filename or - for stdin)
+        file: String,
+    },
+    /// Delete a fixed subscription
+    Delete {
+        /// Subscription ID
+        id: i32,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+    /// Get available Redis versions for fixed subscription
+    #[command(name = "redis-versions")]
+    RedisVersions {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+    },
+}
+
 /// Cloud Provider Account Commands
 #[derive(Subcommand, Debug)]
 pub enum CloudProviderAccountCommands {
@@ -784,6 +843,9 @@ pub enum CloudCommands {
     /// Fixed database operations
     #[command(subcommand, name = "fixed-database")]
     FixedDatabase(CloudFixedDatabaseCommands),
+    /// Fixed subscription operations
+    #[command(subcommand, name = "fixed-subscription")]
+    FixedSubscription(CloudFixedSubscriptionCommands),
 }
 
 /// Enterprise-specific commands (placeholder for now)

--- a/crates/redisctl/src/commands/cloud/fixed_subscription.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_subscription.rs
@@ -1,0 +1,223 @@
+//! Fixed subscription command implementations
+
+#![allow(dead_code)]
+
+use crate::cli::{CloudFixedSubscriptionCommands, OutputFormat};
+use crate::commands::cloud::utils::{
+    confirm_action, handle_output, print_formatted_output, read_file_input,
+};
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+use anyhow::Context;
+use redis_cloud::fixed::subscriptions::{
+    FixedSubscriptionCreateRequest, FixedSubscriptionHandler, FixedSubscriptionUpdateRequest,
+};
+
+/// Handle fixed subscription commands
+pub async fn handle_fixed_subscription_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &CloudFixedSubscriptionCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr
+        .create_cloud_client(profile_name)
+        .await
+        .context("Failed to create Cloud client")?;
+
+    let handler = FixedSubscriptionHandler::new(client);
+
+    match command {
+        CloudFixedSubscriptionCommands::ListPlans { provider } => {
+            let plans = if let Some(provider_filter) = provider {
+                // If provider specified, fetch all plans and filter
+                let all_plans = handler
+                    .list_plans(None, None)
+                    .await
+                    .context("Failed to list fixed subscription plans")?;
+
+                // Convert to JSON for filtering
+                let mut json_plans = serde_json::to_value(all_plans)?;
+
+                // Filter by provider if the structure supports it
+                if let Some(plans_array) = json_plans.as_array_mut() {
+                    plans_array.retain(|plan| {
+                        plan.get("cloudProvider")
+                            .and_then(|p| p.as_str())
+                            .map(|p| p.eq_ignore_ascii_case(provider_filter))
+                            .unwrap_or(false)
+                    });
+                }
+
+                json_plans
+            } else {
+                // No filter, get all plans
+                let plans = handler
+                    .list_plans(None, None)
+                    .await
+                    .context("Failed to list fixed subscription plans")?;
+                serde_json::to_value(plans)?
+            };
+
+            let data = handle_output(plans, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::GetPlans { subscription } => {
+            let plans = handler
+                .get_plans_by_subscription_id(*subscription)
+                .await
+                .context("Failed to get subscription plans")?;
+
+            let json_response =
+                serde_json::to_value(plans).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::GetPlan { id } => {
+            let plan = handler
+                .get_plan_by_id(*id)
+                .await
+                .context("Failed to get plan details")?;
+
+            let json_response =
+                serde_json::to_value(plan).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::List => {
+            let subscriptions = handler
+                .list()
+                .await
+                .context("Failed to list fixed subscriptions")?;
+
+            let json_response =
+                serde_json::to_value(subscriptions).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::Get { id } => {
+            let subscription = handler
+                .get_by_id(*id)
+                .await
+                .context("Failed to get fixed subscription")?;
+
+            let json_response =
+                serde_json::to_value(subscription).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::Create { file } => {
+            let json_string = read_file_input(file)?;
+            let request: FixedSubscriptionCreateRequest =
+                serde_json::from_str(&json_string).context("Invalid subscription configuration")?;
+
+            let result = handler
+                .create(&request)
+                .await
+                .context("Failed to create fixed subscription")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!(
+                    "Fixed subscription creation initiated. Task ID: {}",
+                    task_id
+                );
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::Update { id, file } => {
+            let json_string = read_file_input(file)?;
+            let request: FixedSubscriptionUpdateRequest =
+                serde_json::from_str(&json_string).context("Invalid update configuration")?;
+
+            let result = handler
+                .update(*id, &request)
+                .await
+                .context("Failed to update fixed subscription")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!("Fixed subscription update initiated. Task ID: {}", task_id);
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::Delete { id, yes } => {
+            if !yes {
+                let prompt = format!("Delete fixed subscription {}?", id);
+                if !confirm_action(&prompt)? {
+                    eprintln!("Operation cancelled");
+                    return Ok(());
+                }
+            }
+
+            let result = handler
+                .delete_by_id(*id)
+                .await
+                .context("Failed to delete fixed subscription")?;
+
+            // Check if response contains a task ID
+            let json_result =
+                serde_json::to_value(&result).context("Failed to serialize response")?;
+            if let Some(task_id) = json_result.get("taskId").and_then(|v| v.as_str()) {
+                eprintln!(
+                    "Fixed subscription deletion initiated. Task ID: {}",
+                    task_id
+                );
+                eprintln!(
+                    "Use 'redisctl cloud task wait {}' to monitor progress",
+                    task_id
+                );
+            } else {
+                eprintln!("Fixed subscription deleted successfully");
+            }
+
+            let data = handle_output(json_result, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+
+        CloudFixedSubscriptionCommands::RedisVersions { subscription } => {
+            let versions = handler
+                .get_redis_versions(*subscription)
+                .await
+                .context("Failed to get Redis versions")?;
+
+            let json_response =
+                serde_json::to_value(versions).context("Failed to serialize response")?;
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
+    }
+}

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -16,6 +16,7 @@ pub mod connectivity;
 pub mod database;
 pub mod database_impl;
 pub mod fixed_database;
+pub mod fixed_subscription;
 pub mod subscription;
 pub mod subscription_impl;
 pub mod task;

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -454,5 +454,15 @@ async fn execute_cloud_command(
             )
             .await
         }
+        FixedSubscription(fixed_sub_cmd) => {
+            commands::cloud::fixed_subscription::handle_fixed_subscription_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                fixed_sub_cmd,
+                cli.output,
+                cli.query.as_deref(),
+            )
+            .await
+        }
     }
 }


### PR DESCRIPTION
## Summary
Implements fixed subscription commands for managing Redis Cloud plans with predetermined resources and pricing (vs flexible/pay-as-you-go subscriptions).

## Changes
- Add 9 fixed subscription commands covering plan and subscription management
- Support listing plans with optional provider filtering (AWS, GCP, Azure)
- Implement full CRUD operations for fixed subscriptions
- Add Redis version listing for fixed subscriptions  
- Handle async operations with task ID feedback for monitoring
- Include confirmation prompts for destructive operations

## Commands Added

### Plans Management
- `redisctl cloud fixed-subscription list-plans [--provider PROVIDER]` - List all available fixed subscription plans
- `redisctl cloud fixed-subscription get-plans --subscription ID` - Get plans for a specific subscription
- `redisctl cloud fixed-subscription get-plan ID` - Get details of a specific plan

### Subscription Operations
- `redisctl cloud fixed-subscription list` - List all fixed subscriptions
- `redisctl cloud fixed-subscription get ID` - Get details of a fixed subscription
- `redisctl cloud fixed-subscription create @config.json` - Create a new fixed subscription
- `redisctl cloud fixed-subscription update ID @update.json` - Update fixed subscription
- `redisctl cloud fixed-subscription delete ID` - Delete a fixed subscription

### Version Information
- `redisctl cloud fixed-subscription redis-versions --subscription ID` - Get available Redis versions

## Testing
- ✅ cargo build
- ✅ cargo clippy
- ✅ cargo test

## Notes
- Fixed subscriptions use pre-defined plans with set resources (e.g., 30MB, 250MB, 1GB)
- This complements flexible subscriptions which are pay-as-you-go with configurable resources
- Plan filtering by provider helps users find relevant options for their cloud infrastructure
- The CLI clearly distinguishes between fixed and flexible subscription types

Resolves #122