### PR TITLE
feat(cloud): add --wait flag to subscription commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -953,6 +953,9 @@ pub enum CloudSubscriptionCommands {
         /// Subscription configuration as JSON string or @file.json
         #[arg(long)]
         data: String,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Update subscription configuration
@@ -962,6 +965,9 @@ pub enum CloudSubscriptionCommands {
         /// Update configuration as JSON string or @file.json
         #[arg(long)]
         data: String,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Delete a subscription
@@ -971,6 +977,9 @@ pub enum CloudSubscriptionCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Get available Redis versions

--- a/crates/redisctl/src/commands/cloud/subscription.rs
+++ b/crates/redisctl/src/commands/cloud/subscription.rs
@@ -49,33 +49,44 @@ pub async fn handle_subscription_command(
         CloudSubscriptionCommands::Get { id } => {
             get_subscription(conn_mgr, profile_name, *id, output_format, query).await
         }
-        CloudSubscriptionCommands::Create { data } => {
+        CloudSubscriptionCommands::Create { data, async_ops } => {
             subscription_impl::create_subscription(
                 conn_mgr,
                 profile_name,
                 data,
+                async_ops,
                 output_format,
                 query,
             )
             .await
         }
-        CloudSubscriptionCommands::Update { id, data } => {
+        CloudSubscriptionCommands::Update {
+            id,
+            data,
+            async_ops,
+        } => {
             subscription_impl::update_subscription(
                 conn_mgr,
                 profile_name,
                 *id,
                 data,
+                async_ops,
                 output_format,
                 query,
             )
             .await
         }
-        CloudSubscriptionCommands::Delete { id, force } => {
+        CloudSubscriptionCommands::Delete {
+            id,
+            force,
+            async_ops,
+        } => {
             subscription_impl::delete_subscription(
                 conn_mgr,
                 profile_name,
                 *id,
                 *force,
+                async_ops,
                 output_format,
                 query,
             )

--- a/crates/redisctl/src/commands/cloud/subscription_impl.rs
+++ b/crates/redisctl/src/commands/cloud/subscription_impl.rs
@@ -1,5 +1,6 @@
 //! Implementation of additional subscription commands
 
+use super::async_utils::{AsyncOperationArgs, handle_async_response};
 use super::utils::*;
 use crate::cli::OutputFormat;
 use crate::connection::ConnectionManager;
@@ -41,6 +42,7 @@ pub async fn create_subscription(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
     data: &str,
+    async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
@@ -52,26 +54,16 @@ pub async fn create_subscription(
         .await
         .context("Failed to create subscription")?;
 
-    let result = if let Some(q) = query {
-        apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    match output_format {
-        OutputFormat::Table => {
-            println!("Subscription created successfully");
-            if let Some(task_id) = result.get("taskId") {
-                println!("Task ID: {}", task_id);
-            }
-            if let Some(sub_id) = result.get("resourceId") {
-                println!("Subscription ID: {}", sub_id);
-            }
-        }
-        _ => print_json_or_yaml(result, output_format)?,
-    }
-
-    Ok(())
+    handle_async_response(
+        conn_mgr,
+        profile_name,
+        response,
+        async_ops,
+        output_format,
+        query,
+        "Subscription created successfully",
+    )
+    .await
 }
 
 /// Update subscription configuration
@@ -80,6 +72,7 @@ pub async fn update_subscription(
     profile_name: Option<&str>,
     id: u32,
     data: &str,
+    async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
@@ -91,23 +84,16 @@ pub async fn update_subscription(
         .await
         .context("Failed to update subscription")?;
 
-    let result = if let Some(q) = query {
-        apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    match output_format {
-        OutputFormat::Table => {
-            println!("Subscription updated successfully");
-            if let Some(task_id) = result.get("taskId") {
-                println!("Task ID: {}", task_id);
-            }
-        }
-        _ => print_json_or_yaml(result, output_format)?,
-    }
-
-    Ok(())
+    handle_async_response(
+        conn_mgr,
+        profile_name,
+        response,
+        async_ops,
+        output_format,
+        query,
+        "Subscription updated successfully",
+    )
+    .await
 }
 
 /// Delete a subscription
@@ -116,6 +102,7 @@ pub async fn delete_subscription(
     profile_name: Option<&str>,
     id: u32,
     force: bool,
+    async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
@@ -143,23 +130,16 @@ pub async fn delete_subscription(
         .await
         .context("Failed to delete subscription")?;
 
-    let result = if let Some(q) = query {
-        apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    match output_format {
-        OutputFormat::Table => {
-            println!("Subscription deletion initiated");
-            if let Some(task_id) = result.get("taskId") {
-                println!("Task ID: {}", task_id);
-            }
-        }
-        _ => print_json_or_yaml(result, output_format)?,
-    }
-
-    Ok(())
+    handle_async_response(
+        conn_mgr,
+        profile_name,
+        response,
+        async_ops,
+        output_format,
+        query,
+        "Subscription deletion initiated",
+    )
+    .await
 }
 
 /// Redis version info for table display


### PR DESCRIPTION
## Summary

Adds `--wait` flag support to Cloud subscription operations, building on the foundation from #191.

Fixes #192
Part of #175

## What's Changed

- ✅ Added `AsyncOperationArgs` to subscription Create, Update, and Delete commands
- ✅ Updated command handlers to pass async_ops parameter through the call chain
- ✅ Modified subscription_impl functions to use `handle_async_response()` from async_utils
- ✅ All three operations now support `--wait`, `--wait-timeout`, and `--wait-interval` flags

## Implementation Details

This PR follows the exact same pattern established in #191:
1. Add `AsyncOperationArgs` via `#[command(flatten)]` to the CLI enum
2. Pass the parameter through command handlers
3. Replace manual task ID handling with `handle_async_response()` call

## Testing

- [x] Compiles successfully
- [x] Clippy passes with no warnings
- [x] Help text shows new flags correctly
- [ ] Manual testing with real API (requires credentials)

## Example Usage

```bash
# Create subscription and wait for completion
redisctl cloud subscription create --data @config.json --wait

# Update subscription with custom timeout
redisctl cloud subscription update 123 --data @update.json --wait --wait-timeout 600

# Delete subscription with confirmation and wait
redisctl cloud subscription delete 456 --force --wait
```

## Next Steps

After this PR, the remaining commands to update are:
- Fixed database/subscription (#193) - 8 commands
- ACL operations (#194) - 9 commands  
- User & provider accounts (#195) - 4 commands
- Connectivity operations (#196) - ~20 commands