### PR TITLE
feat(redisctl): add --wait flag support for Cloud user and provider account operations

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -858,6 +858,9 @@ pub enum CloudProviderAccountCommands {
         /// For GCP, this should be the service account JSON file
         /// Use @filename to read from file
         file: String,
+        /// Async operation arguments
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
     /// Update a cloud provider account
     Update {
@@ -866,6 +869,9 @@ pub enum CloudProviderAccountCommands {
         /// JSON file containing updated cloud account configuration
         /// Use @filename to read from file
         file: String,
+        /// Async operation arguments
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
     /// Delete a cloud provider account
     Delete {
@@ -874,6 +880,9 @@ pub enum CloudProviderAccountCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Async operation arguments
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 }
 
@@ -1321,6 +1330,9 @@ pub enum CloudUserCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Async operation arguments
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 }
 

--- a/crates/redisctl/src/commands/cloud/cloud_account.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use crate::cli::{CloudProviderAccountCommands, OutputFormat};
-use crate::commands::cloud::cloud_account_impl;
+use crate::commands::cloud::cloud_account_impl::{self, CloudAccountOperationParams};
 use crate::commands::cloud::utils::create_cloud_client_raw;
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;
@@ -23,15 +23,46 @@ pub async fn handle_cloud_account_command(
         CloudProviderAccountCommands::Get { account_id } => {
             cloud_account_impl::handle_get(&client, *account_id, output_format, query).await
         }
-        CloudProviderAccountCommands::Create { file } => {
-            cloud_account_impl::handle_create(&client, file, output_format, query).await
+        CloudProviderAccountCommands::Create { file, async_ops } => {
+            let params = CloudAccountOperationParams {
+                conn_mgr,
+                profile_name,
+                client: &client,
+                async_ops,
+                output_format,
+                query,
+            };
+            cloud_account_impl::handle_create(&params, file).await
         }
-        CloudProviderAccountCommands::Update { account_id, file } => {
-            cloud_account_impl::handle_update(&client, *account_id, file, output_format, query)
-                .await
+        CloudProviderAccountCommands::Update {
+            account_id,
+            file,
+            async_ops,
+        } => {
+            let params = CloudAccountOperationParams {
+                conn_mgr,
+                profile_name,
+                client: &client,
+                async_ops,
+                output_format,
+                query,
+            };
+            cloud_account_impl::handle_update(&params, *account_id, file).await
         }
-        CloudProviderAccountCommands::Delete { account_id, force } => {
-            cloud_account_impl::handle_delete(&client, *account_id, *force).await
+        CloudProviderAccountCommands::Delete {
+            account_id,
+            force,
+            async_ops,
+        } => {
+            let params = CloudAccountOperationParams {
+                conn_mgr,
+                profile_name,
+                client: &client,
+                async_ops,
+                output_format,
+                query,
+            };
+            cloud_account_impl::handle_delete(&params, *account_id, *force).await
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for the `--wait` flag to Cloud user and provider account operations, allowing users to wait for async operations to complete.

## Changes

- Added `AsyncOperationArgs` to `CloudUserCommands::Delete` command
- Added `AsyncOperationArgs` to all `CloudProviderAccountCommands` (Create, Update, Delete)
- Updated `delete_user` function to use `handle_async_response` for consistent async operation handling
- Created `CloudAccountOperationParams` struct to group common parameters and avoid clippy's too_many_arguments warning
- Updated all provider account handlers to support async operations while maintaining backward compatibility

## Testing

- ✅ All existing tests pass
- ✅ No clippy warnings
- ✅ Code formatted with cargo fmt

## Related Issues

Fixes #195

## Backwards Compatibility

The changes maintain full backward compatibility - if the wait flags are not specified, operations behave synchronously as before.