### PR TITLE
feat(redisctl): add --wait flag support for Cloud ACL commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -1352,6 +1352,9 @@ pub enum CloudAclCommands {
         /// Redis ACL rule (e.g., "+@read")
         #[arg(long)]
         rule: String,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Update an existing Redis ACL rule
@@ -1365,6 +1368,9 @@ pub enum CloudAclCommands {
         /// New Redis ACL rule
         #[arg(long)]
         rule: Option<String>,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Delete a Redis ACL rule
@@ -1375,6 +1381,9 @@ pub enum CloudAclCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     // ACL Roles
@@ -1391,6 +1400,9 @@ pub enum CloudAclCommands {
         /// Redis rules (JSON array or single rule ID)
         #[arg(long, value_name = "JSON|ID")]
         redis_rules: String,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Update an existing ACL role
@@ -1404,6 +1416,9 @@ pub enum CloudAclCommands {
         /// New Redis rules (JSON array or single rule ID)
         #[arg(long, value_name = "JSON|ID")]
         redis_rules: Option<String>,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Delete an ACL role
@@ -1414,6 +1429,9 @@ pub enum CloudAclCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     // ACL Users
@@ -1440,6 +1458,9 @@ pub enum CloudAclCommands {
         /// Password
         #[arg(long)]
         password: String,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Update an ACL user
@@ -1456,6 +1477,9 @@ pub enum CloudAclCommands {
         /// New password
         #[arg(long)]
         password: Option<String>,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 
     /// Delete an ACL user
@@ -1466,6 +1490,9 @@ pub enum CloudAclCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
 }
 

--- a/crates/redisctl/src/commands/cloud/acl.rs
+++ b/crates/redisctl/src/commands/cloud/acl.rs
@@ -4,7 +4,7 @@ use crate::cli::{CloudAclCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;
 
-use super::acl_impl;
+use super::acl_impl::{self, AclOperationParams};
 
 pub async fn handle_acl_command(
     conn_mgr: &ConnectionManager,
@@ -18,60 +18,96 @@ pub async fn handle_acl_command(
         CloudAclCommands::ListRedisRules => {
             acl_impl::list_redis_rules(conn_mgr, profile_name, output_format, query).await
         }
-        CloudAclCommands::CreateRedisRule { name, rule } => {
-            acl_impl::create_redis_rule(conn_mgr, profile_name, name, rule, output_format, query)
-                .await
-        }
-        CloudAclCommands::UpdateRedisRule { id, name, rule } => {
-            acl_impl::update_redis_rule(
+        CloudAclCommands::CreateRedisRule {
+            name,
+            rule,
+            async_ops,
+        } => {
+            let params = AclOperationParams {
                 conn_mgr,
                 profile_name,
-                *id,
-                name.as_deref(),
-                rule.as_deref(),
+                async_ops,
                 output_format,
                 query,
-            )
-            .await
+            };
+            acl_impl::create_redis_rule(&params, name, rule).await
         }
-        CloudAclCommands::DeleteRedisRule { id, force } => {
-            acl_impl::delete_redis_rule(conn_mgr, profile_name, *id, *force, output_format, query)
-                .await
+        CloudAclCommands::UpdateRedisRule {
+            id,
+            name,
+            rule,
+            async_ops,
+        } => {
+            let params = AclOperationParams {
+                conn_mgr,
+                profile_name,
+                async_ops,
+                output_format,
+                query,
+            };
+            acl_impl::update_redis_rule(&params, *id, name.as_deref(), rule.as_deref()).await
+        }
+        CloudAclCommands::DeleteRedisRule {
+            id,
+            force,
+            async_ops,
+        } => {
+            let params = AclOperationParams {
+                conn_mgr,
+                profile_name,
+                async_ops,
+                output_format,
+                query,
+            };
+            acl_impl::delete_redis_rule(&params, *id, *force).await
         }
 
         // ACL Roles
         CloudAclCommands::ListRoles => {
             acl_impl::list_roles(conn_mgr, profile_name, output_format, query).await
         }
-        CloudAclCommands::CreateRole { name, redis_rules } => {
-            acl_impl::create_role(
+        CloudAclCommands::CreateRole {
+            name,
+            redis_rules,
+            async_ops,
+        } => {
+            let params = AclOperationParams {
                 conn_mgr,
                 profile_name,
-                name,
-                redis_rules,
+                async_ops,
                 output_format,
                 query,
-            )
-            .await
+            };
+            acl_impl::create_role(&params, name, redis_rules).await
         }
         CloudAclCommands::UpdateRole {
             id,
             name,
             redis_rules,
+            async_ops,
         } => {
-            acl_impl::update_role(
+            let params = AclOperationParams {
                 conn_mgr,
                 profile_name,
-                *id,
-                name.as_deref(),
-                redis_rules.as_deref(),
+                async_ops,
                 output_format,
                 query,
-            )
-            .await
+            };
+            acl_impl::update_role(&params, *id, name.as_deref(), redis_rules.as_deref()).await
         }
-        CloudAclCommands::DeleteRole { id, force } => {
-            acl_impl::delete_role(conn_mgr, profile_name, *id, *force, output_format, query).await
+        CloudAclCommands::DeleteRole {
+            id,
+            force,
+            async_ops,
+        } => {
+            let params = AclOperationParams {
+                conn_mgr,
+                profile_name,
+                async_ops,
+                output_format,
+                query,
+            };
+            acl_impl::delete_role(&params, *id, *force).await
         }
 
         // ACL Users
@@ -85,39 +121,53 @@ pub async fn handle_acl_command(
             name,
             role,
             password,
+            async_ops,
         } => {
-            acl_impl::create_acl_user(
+            let params = AclOperationParams {
                 conn_mgr,
                 profile_name,
-                name,
-                role,
-                password,
+                async_ops,
                 output_format,
                 query,
-            )
-            .await
+            };
+            acl_impl::create_acl_user(&params, name, role, password).await
         }
         CloudAclCommands::UpdateAclUser {
             id,
             name,
             role,
             password,
+            async_ops,
         } => {
-            acl_impl::update_acl_user(
+            let params = AclOperationParams {
                 conn_mgr,
                 profile_name,
+                async_ops,
+                output_format,
+                query,
+            };
+            acl_impl::update_acl_user(
+                &params,
                 *id,
                 name.as_deref(),
                 role.as_deref(),
                 password.as_deref(),
-                output_format,
-                query,
             )
             .await
         }
-        CloudAclCommands::DeleteAclUser { id, force } => {
-            acl_impl::delete_acl_user(conn_mgr, profile_name, *id, *force, output_format, query)
-                .await
+        CloudAclCommands::DeleteAclUser {
+            id,
+            force,
+            async_ops,
+        } => {
+            let params = AclOperationParams {
+                conn_mgr,
+                profile_name,
+                async_ops,
+                output_format,
+                query,
+            };
+            acl_impl::delete_acl_user(&params, *id, *force).await
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for the `--wait` flag to all Cloud ACL operations, allowing users to wait for async operations to complete.

## Changes

### ACL Redis Rules (3 commands)
- ✅ `cloud acl create-redis-rule` - Creating ACL rules
- ✅ `cloud acl update-redis-rule` - Updating ACL rules  
- ✅ `cloud acl delete-redis-rule` - Deleting ACL rules

### ACL Roles (3 commands)
- ✅ `cloud acl create-role` - Creating ACL roles
- ✅ `cloud acl update-role` - Updating ACL roles
- ✅ `cloud acl delete-role` - Deleting ACL roles

### ACL Users (3 commands)
- ✅ `cloud acl create-acl-user` - Creating ACL users
- ✅ `cloud acl update-acl-user` - Updating ACL users
- ✅ `cloud acl delete-acl-user` - Deleting ACL users

## Implementation Details

- Added `AsyncOperationArgs` to all 9 ACL command variants in `CloudAclCommands` enum
- Updated all handler functions to use `handle_async_response` for consistent async operation handling
- Created `AclOperationParams` struct to group common parameters and avoid clippy's too_many_arguments warning
- All delete operations work with both `--force` and `--wait` flags

## Testing

- ✅ All existing tests pass
- ✅ No clippy warnings
- ✅ Code formatted with cargo fmt

## Example Usage

```bash
# Create ACL rule and wait
redisctl cloud acl create-redis-rule --name "read-only" --rule "+@read" --wait

# Delete role with force and wait
redisctl cloud acl delete-role --id 789 --force --wait

# Create ACL user with custom timeout
redisctl cloud acl create-acl-user --username "app-user" --role-ids 123,456 --wait --wait-timeout 120
```

## Related Issues

Fixes #194
Part of #175 (Cloud async operations support)

## Backwards Compatibility

The changes maintain full backward compatibility - if the wait flags are not specified, operations behave synchronously as before.