### PR TITLE
fix: remove version constraints from workspace dependencies

### DIFF
--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -16,8 +16,8 @@ name = "redisctl"
 path = "src/main.rs"
 
 [dependencies]
-redis-cloud = { version = "0.1.2", path = "../redis-cloud" }
-redis-enterprise = { version = "0.2.0", path = "../redis-enterprise" }
+redis-cloud = { path = "../redis-cloud" }
+redis-enterprise = { path = "../redis-enterprise" }
 
 # CLI dependencies
 clap = { workspace = true }


### PR DESCRIPTION
Another quick fix for the release process. Path dependencies in a workspace don't need version constraints. Having them causes issues during release preparation when versions are bumped but not yet published to crates.io.

This should allow the prepare-release workflow to complete successfully.