### PR TITLE
fix: remove invalid consolidate-pushes field from release.toml

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,6 @@
-# Cargo Release Configuration for Workspace
+# Cargo Release Configuration
+# Based on official cargo-release documentation
+# https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
 
 # Only allow releases from main branch
 allow-branch = ["main"]
@@ -8,19 +10,23 @@ sign-commit = false
 sign-tag = false
 
 # Push and publish settings
-push = true  # Push after successful release
+push = true
 publish = true
 verify = true
 
 # Shared version for all workspace members
 shared-version = true
 
-# Version bump configuration
+# Consolidate commits when releasing workspace
+consolidate-commits = true
+
+# Version bump commit message
 pre-release-commit-message = "chore: release v{{version}}"
+
+# Tag configuration
+tag = true
 tag-message = "Release v{{version}}"
 tag-name = "v{{version}}"
-consolidate-commits = true
-consolidate-pushes = true
 
 # Don't create GitHub releases - cargo-dist will handle that
 release = false


### PR DESCRIPTION
## Summary

Fixes the release workflow failure by removing the invalid `consolidate-pushes` field from release.toml.

## Problem

The manual release workflow failed with:
```
error: Failed to parse release.toml: 
unknown field 'consolidate-pushes'
```

## Root Cause

After checking the [official cargo-release documentation](https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md), `consolidate-pushes` is **NOT** a valid configuration field.

## Solution

- ✅ Removed invalid `consolidate-pushes` field
- ✅ Kept valid `consolidate-commits` field
- ✅ Added explicit `tag = true` for clarity
- ✅ Added documentation reference in comments

## Valid Fields Reference

Based on the official docs, these are the valid fields we're using:
- `allow-branch`
- `sign-commit`, `sign-tag`
- `push`, `publish`, `verify`
- `shared-version`
- `consolidate-commits` (NOT consolidate-pushes!)
- `pre-release-commit-message`
- `tag`, `tag-message`, `tag-name`
- `release`
- `dependent-version`

## Testing

The configuration now contains only valid fields according to cargo-release documentation.

This is an urgent fix needed to unblock releases!