### PR TITLE
fix: remove invalid [[package]] sections from release.toml

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -33,13 +33,3 @@ release = false
 
 # Dependencies between crates - automatically upgrade
 dependent-version = "upgrade"
-
-# Package-specific configuration (all use workspace defaults)
-[[package]]
-name = "redis-cloud"
-
-[[package]]
-name = "redis-enterprise"
-
-[[package]]
-name = "redisctl"


### PR DESCRIPTION
## Summary

Simple fix - remove the invalid `[[package]]` sections that are causing release failures.

## Problem

Latest release attempt failed with:
```
error: unknown field 'package'
```

## Solution

Remove the `[[package]]` sections. These are not valid in release.toml.

## What remains

A clean release.toml with only valid fields:
- allow-branch
- sign-commit, sign-tag  
- push, publish, verify
- shared-version
- consolidate-commits
- pre-release-commit-message
- tag, tag-message, tag-name
- release
- dependent-version

All of these are confirmed valid per the error message.

This should unblock releases immediately.