### PR TITLE
fix: add --workspace flag to cargo-release command

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -64,7 +64,8 @@ jobs:
           echo "Releasing ${{ inputs.version }} version..."
 
           # Run cargo-release - it will handle everything
-          cargo release ${{ inputs.version }} --execute --no-confirm --verbose || {
+          # Use --workspace to release all workspace packages
+          cargo release ${{ inputs.version }} --workspace --execute --no-confirm --verbose || {
             echo "::error::cargo-release failed. Check the logs above for details."
             exit 1
           }


### PR DESCRIPTION
## Summary

Fixes the 'no packages selected' error by adding the `--workspace` flag to cargo-release.

## Problem

Release workflow failed with:
```
error: no packages selected
```

## Solution

Add `--workspace` flag to the cargo-release command to release all workspace packages together.

### Before:
```bash
cargo release patch --execute --no-confirm --verbose
```

### After:
```bash
cargo release patch --workspace --execute --no-confirm --verbose
```

## Why This Works

- The workspace has 3 packages: redis-cloud, redis-enterprise, redisctl
- Without `--workspace`, cargo-release doesn't know which packages to release
- With `--workspace`, it releases all workspace members together
- This aligns with our `shared-version = true` configuration

This should finally make releases work!