### PR TITLE
fix: add package.metadata.release to all packages

### DIFF
--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["redis", "cloud", "api", "rest", "client"]
 categories = ["api-bindings", "database"]
 readme = "../../README.md"
 
+[package.metadata.release]
+# Use workspace configuration
+
 [dependencies]
 async-trait = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["redis", "enterprise", "api", "rest", "client"]
 categories = ["api-bindings", "database"]
 readme = "../../README.md"
 
+[package.metadata.release]
+# Use workspace configuration
+
 [dependencies]
 async-trait = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -15,6 +15,9 @@ readme = "../../README.md"
 name = "redisctl"
 path = "src/main.rs"
 
+[package.metadata.release]
+# Use workspace configuration
+
 [dependencies]
 redis-cloud = { version = "0.3.1", path = "../redis-cloud" }
 redis-enterprise = { version = "0.3.1", path = "../redis-enterprise" }


### PR DESCRIPTION
## Summary

Fixes the 'no packages selected' error by adding `[package.metadata.release]` sections to all packages.

## Problem

Even with `--workspace` flag, cargo-release still reports:
```
error: no packages selected
```

## Root Cause

cargo-release needs packages to have `[package.metadata.release]` sections to recognize them as releasable packages, even if the sections are empty and just inherit workspace configuration.

## Solution

Added to each package's Cargo.toml:
```toml
[package.metadata.release]
# Use workspace configuration
```

This explicitly marks each package as participating in releases.

## Testing

With these sections, cargo-release should now:
1. Recognize all 3 packages as releasable
2. Apply workspace configuration to all of them
3. Release them together with synchronized versions

This should finally fix the 'no packages selected' error!