### PR TITLE
fix: explicitly specify packages in cargo-release command

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -82,8 +82,12 @@ jobs:
           echo "Releasing ${{ inputs.version }} version..."
 
           # Run cargo-release - it will handle everything
-          # Use --workspace to release all workspace packages
-          cargo release ${{ inputs.version }} --workspace --execute --no-confirm --verbose || {
+          # Explicitly specify all packages to release
+          cargo release ${{ inputs.version }} \
+            --package redis-cloud \
+            --package redis-enterprise \
+            --package redisctl \
+            --execute --no-confirm --verbose || {
             echo "::error::cargo-release failed. Check the logs above for details."
             exit 1
           }


### PR DESCRIPTION
## Summary

Stop relying on --workspace and explicitly list every package to release.

## Problem

STILL getting 'no packages selected' error even with:
- ✅ default-members configured
- ✅ --workspace flag
- ✅ [package.metadata.release] in each package
- ✅ Correct release.toml

## Solution

Forget --workspace. Just explicitly list every single package:

```bash
cargo release patch \
  --package redis-cloud \
  --package redis-enterprise \
  --package redisctl \
  --execute --no-confirm --verbose
```

## Why This Should Work

- No ambiguity about which packages to release
- Each package is explicitly named
- This is the most explicit way possible

If this doesn't work, we might need to consider alternatives to cargo-release entirely.

**This is getting ridiculous, but let's try this.**