### PR TITLE
fix: use workspace-level release to resolve 'no packages selected' error

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -82,8 +82,12 @@ jobs:
           echo "Releasing ${{ inputs.version }} version..."
 
           # Run cargo-release - it will handle everything
-          # Use --workspace to release all workspace packages
-          cargo release ${{ inputs.version }} --workspace --execute --no-confirm --verbose || {
+          # Explicitly specify all packages to release
+          cargo release ${{ inputs.version }} \
+            --package redis-cloud \
+            --package redis-enterprise \
+            --package redisctl \
+            --execute --no-confirm --verbose || {
             echo "::error::cargo-release failed. Check the logs above for details."
             exit 1
           }

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -82,11 +82,8 @@ jobs:
           echo "Releasing ${{ inputs.version }} version..."
 
           # Run cargo-release - it will handle everything
-          # Explicitly specify all packages to release
+          # Use workspace-level release with shared-version
           cargo release ${{ inputs.version }} \
-            --package redis-cloud \
-            --package redis-enterprise \
-            --package redisctl \
             --execute --no-confirm --verbose || {
             echo "::error::cargo-release failed. Check the logs above for details."
             exit 1


### PR DESCRIPTION
## Problem
The manual release workflow keeps failing with 'no packages selected' error despite multiple attempts to fix it.

## Root Cause
When using `shared-version = true` in release.toml, cargo-release expects to run at the workspace level, not with explicit --package flags.

## Solution
Remove the explicit package flags and run cargo-release at the workspace level. This aligns with our shared-version configuration.

## Changes
- Remove --package flags from cargo release command
- Use workspace-level release which will handle all packages automatically

This should finally fix the persistent 'no packages selected' error.