### PR TITLE
fix: use PAT_TOKEN to bypass branch protection in release workflow

### DIFF
--- a/.github/workflows/cargo-workspaces-release.yml
+++ b/.github/workflows/cargo-workspaces-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

The cargo-workspaces release workflow is failing because branch protection rules prevent commits to main, even from GitHub Actions.

## Solution

Use a Personal Access Token (PAT_TOKEN) with bypass permissions when available, falling back to the default GITHUB_TOKEN.

## Changes

- Updated  to use  if available
- Maintains backwards compatibility by falling back to 

## Usage

1. Create a fine-grained Personal Access Token with:
   - Repository access to this repo  
   - Contents: Write permission
   - Administration: Write permission (for bypass)
2. Add it as a repository secret named 
3. Release workflows will now bypass branch protection rules

## Context

This fixes the issue encountered in the previous release attempt where version bump commits were rejected, preventing successful releases.

Resolves the branch protection issue from the failed v0.3.3 release.