### PR TITLE
fix: explicitly configure git remote to use PAT_TOKEN for pushes

### DIFF
--- a/.github/workflows/cargo-workspaces-release.yml
+++ b/.github/workflows/cargo-workspaces-release.yml
@@ -57,6 +57,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Configure git remote to use PAT_TOKEN for pushes
+          if [ -n "${{ secrets.PAT_TOKEN }}" ]; then
+            echo "Configuring git to use PAT_TOKEN for pushes"
+            git remote set-url origin https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git
+          else
+            echo "PAT_TOKEN not available, using GITHUB_TOKEN"
+            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          fi
+
       - name: Verify authentication (non-dry-run)
         if: ${{ !inputs.dry_run }}
         env:

--- a/.github/workflows/cargo-workspaces-release.yml
+++ b/.github/workflows/cargo-workspaces-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

The cargo-workspaces release workflow is still failing with branch protection errors even though PAT_TOKEN is configured. The issue is that cargo-workspaces uses git internally for pushes, and the checkout action's token doesn't automatically carry over to git operations.

## Root Cause

While `actions/checkout` uses the PAT_TOKEN, when cargo-workspaces calls `git push` internally, it uses the remote URL that was originally set with GITHUB_TOKEN, not the PAT_TOKEN.

## Solution

Explicitly configure the git remote URL to use PAT_TOKEN for all git operations (pushes, tag creation, etc.).

## Changes

- Added git remote reconfiguration step that sets the remote URL to use PAT_TOKEN
- Includes fallback to GITHUB_TOKEN if PAT_TOKEN is not available
- Adds debug logging to show which token is being used

## Testing

This should resolve the branch protection violations that were preventing version bump commits from being pushed to main.

## Context

Fixes the issue where PAT_TOKEN was configured but git push operations were still being rejected due to branch protection rules.