### PR TITLE
fix: improve PAT_TOKEN handling and debugging in release workflow

### DIFF
--- a/.github/workflows/cargo-workspaces-release.yml
+++ b/.github/workflows/cargo-workspaces-release.yml
@@ -74,17 +74,20 @@ jobs:
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure git
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Configure git remote to use PAT_TOKEN for pushes
-          if [ -n "${{ secrets.PAT_TOKEN }}" ]; then
+          if [ -n "$PAT_TOKEN" ]; then
             echo "Configuring git to use PAT_TOKEN for pushes"
-            git remote set-url origin https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git
+            git remote set-url origin https://x-access-token:$PAT_TOKEN@github.com/${{ github.repository }}.git
           else
             echo "PAT_TOKEN not available, using GITHUB_TOKEN"
-            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+            git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}.git
           fi
 
           echo "Final git remote configuration:"

--- a/.github/workflows/cargo-workspaces-release.yml
+++ b/.github/workflows/cargo-workspaces-release.yml
@@ -52,6 +52,27 @@ jobs:
             echo "cargo-workspaces already installed"
           fi
 
+      - name: Debug token configuration
+        run: |
+          echo "=== Token Debug Information ==="
+          if [ -n "${{ secrets.PAT_TOKEN }}" ]; then
+            echo "✅ PAT_TOKEN is available"
+            echo "PAT_TOKEN length: ${#PAT_TOKEN}"
+          else
+            echo "❌ PAT_TOKEN is NOT available"
+          fi
+
+          if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
+            echo "✅ GITHUB_TOKEN is available"
+          else
+            echo "❌ GITHUB_TOKEN is NOT available"
+          fi
+          echo "Current git remote:"
+          git remote -v
+          echo "=== End Debug ==="
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -65,6 +86,9 @@ jobs:
             echo "PAT_TOKEN not available, using GITHUB_TOKEN"
             git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           fi
+
+          echo "Final git remote configuration:"
+          git remote -v
 
       - name: Verify authentication (non-dry-run)
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Problem

The PAT_TOKEN configuration wasn't working properly to bypass branch protection rules. The debug message "Configuring git to use PAT_TOKEN for pushes" never appeared, indicating the token wasn't being recognized.

## Root Causes

1. **Missing environment variables**: The "Configure git" step didn't have an `env:` block to expose secrets as shell variables
2. **Wrong secret syntax**: Using `${{ secrets.PAT_TOKEN }}` directly in shell conditions doesn't work reliably  
3. **Inconsistent variable access**: Mixed use of direct secret interpolation and environment variables

## Solution

- **Added comprehensive debug output** to show token availability and length
- **Fixed environment variable access** by adding proper `env:` blocks
- **Changed shell conditions** from `${{ secrets.PAT_TOKEN }}` to `$PAT_TOKEN`
- **Standardized variable usage** to use environment variables consistently
- **Added git remote verification** to confirm the final configuration

## Changes

```yaml
# Before (broken)
if [ -n "${{ secrets.PAT_TOKEN }}" ]; then
  git remote set-url origin https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/...

# After (fixed)  
env:
  PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
run: |
  if [ -n "$PAT_TOKEN" ]; then
    git remote set-url origin https://x-access-token:$PAT_TOKEN@github.com/...
```

## Testing

With these fixes, the workflow should:
1. Show clear debug output about token availability
2. Properly configure git to use PAT_TOKEN for pushes
3. Successfully bypass branch protection rules

## Context

This resolves the PAT_TOKEN issues encountered during the v0.3.3 release attempts, preparing the workflow for future releases when branch protection is re-enabled.