### PR TITLE
feat(enterprise): add module management commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2129,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2121,6 +2138,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2934,6 +2952,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1"
 
 # HTTP and APIs
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "multipart"] }
 url = "2.5"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/redis-enterprise/src/lib.rs
+++ b/crates/redis-enterprise/src/lib.rs
@@ -167,11 +167,11 @@
 //! let v1_actions = actions.v1().list().await?; // GET /v1/actions
 //! let v2_actions = actions.v2().list().await?; // GET /v2/actions
 //!
-//! // Modules: v1 and v2
+//! // Modules
 //! let modules = ModuleHandler::new(client.clone());
-//! let all = modules.v1().list().await?;            // GET /v1/modules
-//! // v2 upload body can be an opaque Value or multipart in a higher-level helper
-//! let uploaded = modules.v2().upload(serde_json::json!({"name": "search", "data": "..."})).await?;
+//! let all = modules.list().await?;            // GET /v1/modules
+//! // Upload uses v2 endpoint with fallback to v1
+//! let uploaded = modules.upload(b"module_data".to_vec(), "module.zip").await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/crates/redis-enterprise/src/lib.rs
+++ b/crates/redis-enterprise/src/lib.rs
@@ -387,7 +387,7 @@ pub use nodes::{Node, NodeActionRequest, NodeHandler, NodeStats};
 pub use users::{CreateUserRequest, Role, RoleHandler, UpdateUserRequest, User, UserHandler};
 
 // Module management
-pub use modules::{Module, ModuleHandler, UploadModuleRequest};
+pub use modules::{Module, ModuleHandler};
 
 // Action tracking
 pub use actions::{Action, ActionHandler};

--- a/crates/redis-enterprise/src/modules.rs
+++ b/crates/redis-enterprise/src/modules.rs
@@ -14,8 +14,8 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
     pub uid: String,
-    pub name: String,
-    pub version: String,
+    pub module_name: Option<String>,
+    pub version: Option<u32>,
     pub semantic_version: Option<String>,
     pub author: Option<String>,
     pub description: Option<String>,
@@ -24,8 +24,9 @@ pub struct Module {
     pub command_line_args: Option<String>,
     pub capabilities: Option<Vec<String>>,
     pub min_redis_version: Option<String>,
-    pub min_redis_pack_version: Option<String>,
-
+    pub compatible_redis_version: Option<String>,
+    pub display_name: Option<String>,
+    pub is_bundled: Option<bool>,
     #[serde(flatten)]
     pub extra: Value,
 }
@@ -88,13 +89,6 @@ impl ModuleHandler {
             .await
     }
 
-    /// Upgrade modules for a specific database - POST /v1/modules/upgrade/bdb/{uid}
-    pub async fn upgrade_bdb(&self, bdb_uid: u32, body: Value) -> Result<Module> {
-        self.client
-            .post(&format!("/v1/modules/upgrade/bdb/{}", bdb_uid), &body)
-            .await
-    }
-
     /// Upload module via v2 API - POST /v2/modules
     pub async fn upload_v2(&self, body: Value) -> Result<Module> {
         self.client.post("/v2/modules", &body).await
@@ -103,77 +97,5 @@ impl ModuleHandler {
     /// Delete module via v2 API - DELETE /v2/modules/{uid}
     pub async fn delete_v2(&self, uid: &str) -> Result<()> {
         self.client.delete(&format!("/v2/modules/{}", uid)).await
-    }
-
-    // Versioned accessors
-    pub fn v1(&self) -> v1::ModulesV1 {
-        v1::ModulesV1::new(self.client.clone())
-    }
-
-    pub fn v2(&self) -> v2::ModulesV2 {
-        v2::ModulesV2::new(self.client.clone())
-    }
-}
-
-pub mod v1 {
-    use super::{Module, RestClient};
-    use crate::error::Result;
-    use serde_json::Value;
-
-    pub struct ModulesV1 {
-        client: RestClient,
-    }
-
-    impl ModulesV1 {
-        pub(crate) fn new(client: RestClient) -> Self {
-            Self { client }
-        }
-
-        pub async fn list(&self) -> Result<Vec<Module>> {
-            self.client.get("/v1/modules").await
-        }
-
-        pub async fn get(&self, uid: &str) -> Result<Module> {
-            self.client.get(&format!("/v1/modules/{}", uid)).await
-        }
-
-        pub async fn upload(&self, data: Vec<u8>) -> Result<Module> {
-            let body = serde_json::json!({ "module": data });
-            self.client.post("/v1/modules", &body).await
-        }
-
-        pub async fn delete(&self, uid: &str) -> Result<()> {
-            self.client.delete(&format!("/v1/modules/{}", uid)).await
-        }
-
-        pub async fn update(&self, uid: &str, updates: Value) -> Result<Module> {
-            self.client
-                .put(&format!("/v1/modules/{}", uid), &updates)
-                .await
-        }
-    }
-}
-
-pub mod v2 {
-    use super::{Module, RestClient};
-    use crate::error::Result;
-    use serde_json::Value;
-
-    pub struct ModulesV2 {
-        client: RestClient,
-    }
-
-    impl ModulesV2 {
-        pub(crate) fn new(client: RestClient) -> Self {
-            Self { client }
-        }
-
-        pub async fn upload(&self, body: Value) -> Result<Module> {
-            self.client.post("/v2/modules", &body).await
-        }
-
-        pub async fn delete(&self, uid: &str) -> Result<()> {
-            self.client.delete(&format!("/v2/modules/{}", uid)).await
-        }
     }
 }

--- a/crates/redis-enterprise/tests/module_tests.rs
+++ b/crates/redis-enterprise/tests/module_tests.rs
@@ -21,9 +21,9 @@ fn no_content_response() -> ResponseTemplate {
 fn test_module() -> serde_json::Value {
     json!({
         "uid": "1",
-        "name": "RedisSearch",
-        "version": "2.6.1",
-        "status": "loaded",
+        "module_name": "RedisSearch",
+        "version": 20601,
+        "semantic_version": "2.6.1",
         "capabilities": ["search", "index"]
     })
 }
@@ -39,9 +39,9 @@ async fn test_module_list() {
             test_module(),
             {
                 "uid": "2",
-                "name": "RedisJSON",
-                "version": "2.4.0",
-                "status": "loaded",
+                "module_name": "RedisJSON",
+                "version": 20400,
+                "semantic_version": "2.4.0",
                 "capabilities": ["json"]
             }
         ])))
@@ -87,7 +87,7 @@ async fn test_module_get() {
     assert!(result.is_ok());
     let module = result.unwrap();
     assert_eq!(module.uid, "1");
-    assert_eq!(module.name, "RedisSearch");
+    assert_eq!(module.module_name, Some("RedisSearch".to_string()));
 }
 
 #[tokio::test]
@@ -114,7 +114,7 @@ async fn test_module_upload() {
     assert!(result.is_ok());
     let module = result.unwrap();
     assert_eq!(module.uid, "1");
-    assert_eq!(module.name, "RedisSearch");
+    assert_eq!(module.module_name, Some("RedisSearch".to_string()));
 }
 
 #[tokio::test]

--- a/crates/redis-enterprise/tests/module_tests.rs
+++ b/crates/redis-enterprise/tests/module_tests.rs
@@ -94,6 +94,15 @@ async fn test_module_get() {
 async fn test_module_upload() {
     let mock_server = MockServer::start().await;
 
+    // Mock v2 endpoint as not found
+    Mock::given(method("POST"))
+        .and(path("/v2/modules"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&mock_server)
+        .await;
+
+    // Mock v1 endpoint as success
     Mock::given(method("POST"))
         .and(path("/v1/modules"))
         .and(basic_auth("admin", "password"))
@@ -109,12 +118,13 @@ async fn test_module_upload() {
         .unwrap();
 
     let handler = ModuleHandler::new(client);
-    let result = handler.upload(vec![1, 2, 3, 4]).await; // Mock binary data
+    let result = handler.upload(vec![1, 2, 3, 4], "test.zip").await; // Mock binary data
 
     assert!(result.is_ok());
-    let module = result.unwrap();
-    assert_eq!(module.uid, "1");
-    assert_eq!(module.module_name, Some("RedisSearch".to_string()));
+    let response = result.unwrap();
+    // Response is now a Value, not a Module
+    assert_eq!(response["uid"], "1");
+    assert_eq!(response["module_name"], "RedisSearch");
 }
 
 #[tokio::test]

--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -988,6 +988,10 @@ pub enum EnterpriseCommands {
     /// Active-Active database (CRDB) operations
     #[command(subcommand)]
     Crdb(EnterpriseCrdbCommands),
+
+    /// Module management operations
+    #[command(subcommand)]
+    Module(crate::commands::enterprise::module::ModuleCommands),
 }
 
 // Placeholder command structures - will be expanded in later PRs

--- a/crates/redisctl/src/commands/enterprise/mod.rs
+++ b/crates/redisctl/src/commands/enterprise/mod.rs
@@ -6,6 +6,8 @@ pub mod crdb;
 pub mod crdb_impl;
 pub mod database;
 pub mod database_impl;
+pub mod module;
+pub mod module_impl;
 pub mod node;
 pub mod node_impl;
 pub mod rbac;

--- a/crates/redisctl/src/commands/enterprise/module.rs
+++ b/crates/redisctl/src/commands/enterprise/module.rs
@@ -1,0 +1,43 @@
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum ModuleCommands {
+    /// List all available modules
+    #[command(visible_alias = "ls")]
+    List,
+
+    /// Get module details
+    Get {
+        /// Module UID
+        uid: String,
+    },
+
+    /// Upload new module
+    Upload {
+        /// Module file path (e.g., @module.zip)
+        #[arg(long)]
+        file: String,
+    },
+
+    /// Delete module
+    #[command(visible_alias = "rm")]
+    Delete {
+        /// Module UID
+        uid: String,
+
+        /// Force deletion without confirmation
+        #[arg(long, short)]
+        force: bool,
+    },
+
+    /// Configure module for database
+    #[command(name = "config-bdb")]
+    ConfigBdb {
+        /// Database UID
+        bdb_uid: u32,
+
+        /// Configuration data (JSON file or inline)
+        #[arg(long, value_name = "FILE|JSON")]
+        data: String,
+    },
+}

--- a/crates/redisctl/src/commands/enterprise/module_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/module_impl.rs
@@ -1,0 +1,188 @@
+//! Implementation of enterprise module commands
+#![allow(dead_code)]
+
+use crate::cli::OutputFormat;
+use crate::commands::enterprise::module::ModuleCommands;
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+use anyhow::Context;
+use redis_enterprise::ModuleHandler;
+use std::fs;
+use std::path::Path;
+
+pub async fn handle_module_commands(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    cmd: &ModuleCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    match cmd {
+        ModuleCommands::List => handle_list(conn_mgr, profile_name, output_format, query).await,
+        ModuleCommands::Get { uid } => {
+            handle_get(conn_mgr, profile_name, uid, output_format, query).await
+        }
+        ModuleCommands::Upload { file } => {
+            handle_upload(conn_mgr, profile_name, file, output_format, query).await
+        }
+        ModuleCommands::Delete { uid, force } => {
+            handle_delete(conn_mgr, profile_name, uid, *force, output_format, query).await
+        }
+        ModuleCommands::ConfigBdb { bdb_uid, data } => {
+            handle_config_bdb(conn_mgr, profile_name, *bdb_uid, data, output_format, query).await
+        }
+    }
+}
+
+async fn handle_list(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+    let handler = ModuleHandler::new(client);
+
+    let modules = handler.list().await.context("Failed to list modules")?;
+
+    let modules_json = serde_json::to_value(&modules)?;
+    let output_data = if let Some(q) = query {
+        crate::commands::enterprise::utils::apply_jmespath(&modules_json, q)?
+    } else {
+        modules_json
+    };
+
+    crate::commands::enterprise::utils::print_formatted_output(output_data, output_format)?;
+    Ok(())
+}
+
+async fn handle_get(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    uid: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+    let handler = ModuleHandler::new(client);
+
+    let module = handler.get(uid).await.context("Failed to get module")?;
+
+    let module_json = serde_json::to_value(&module)?;
+    let output_data = if let Some(q) = query {
+        crate::commands::enterprise::utils::apply_jmespath(&module_json, q)?
+    } else {
+        module_json
+    };
+
+    crate::commands::enterprise::utils::print_formatted_output(output_data, output_format)?;
+    Ok(())
+}
+
+async fn handle_upload(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    // Handle @file syntax
+    let file_path = if let Some(path) = file.strip_prefix('@') {
+        path
+    } else {
+        file
+    };
+
+    // Check if file exists
+    if !Path::new(file_path).exists() {
+        return Err(anyhow::anyhow!("Module file not found: {}", file_path).into());
+    }
+
+    // Read file contents
+    let module_data = fs::read(file_path)
+        .with_context(|| format!("Failed to read module file: {}", file_path))?;
+
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+    let handler = ModuleHandler::new(client);
+
+    // Upload module
+    let module = handler
+        .upload(module_data)
+        .await
+        .context("Failed to upload module")?;
+
+    let module_json = serde_json::to_value(&module)?;
+    let output_data = if let Some(q) = query {
+        crate::commands::enterprise::utils::apply_jmespath(&module_json, q)?
+    } else {
+        module_json
+    };
+
+    crate::commands::enterprise::utils::print_formatted_output(output_data, output_format)?;
+    Ok(())
+}
+
+async fn handle_delete(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    uid: &str,
+    force: bool,
+    output_format: OutputFormat,
+    _query: Option<&str>,
+) -> CliResult<()> {
+    // Confirm deletion if not forced
+    if !force {
+        let message = format!("Are you sure you want to delete module '{}'?", uid);
+        if !crate::commands::enterprise::utils::confirm_action(&message)? {
+            println!("Module deletion cancelled");
+            return Ok(());
+        }
+    }
+
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+    let handler = ModuleHandler::new(client);
+
+    handler
+        .delete(uid)
+        .await
+        .context("Failed to delete module")?;
+
+    // Print success message
+    let result = serde_json::json!({
+        "status": "success",
+        "message": format!("Module '{}' deleted successfully", uid)
+    });
+
+    crate::commands::enterprise::utils::print_formatted_output(result, output_format)?;
+    Ok(())
+}
+
+async fn handle_config_bdb(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    bdb_uid: u32,
+    data: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+    let handler = ModuleHandler::new(client);
+
+    // Parse data (from file or inline JSON)
+    let config = crate::commands::enterprise::utils::read_json_data(data)?;
+
+    let result = handler
+        .config_bdb(bdb_uid, config)
+        .await
+        .context("Failed to configure module for database")?;
+
+    let result_json = serde_json::to_value(&result)?;
+    let output_data = if let Some(q) = query {
+        crate::commands::enterprise::utils::apply_jmespath(&result_json, q)?
+    } else {
+        result_json
+    };
+
+    crate::commands::enterprise::utils::print_formatted_output(output_data, output_format)?;
+    Ok(())
+}

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -242,6 +242,12 @@ async fn execute_enterprise_command(
             )
             .await
         }
+        Module(module_cmd) => {
+            commands::enterprise::module_impl::handle_module_commands(
+                conn_mgr, profile, module_cmd, output, query,
+            )
+            .await
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements module management commands for Redis Enterprise (#153).

## Changes

- Add module list, get, upload, delete, and config-bdb commands
- Fix Module struct to match actual API response:
  - Changed `name` field to `module_name`
  - Changed `version` from String to u32
  - Made all fields optional except uid
- Remove upgrade-bdb command as endpoint doesn't exist in API
- Update tests to match new field names
- Document correct config-bdb format in CLAUDE.md

## Testing

All commands tested against local Redis Enterprise instance:
- `module list` - works correctly, lists all available modules
- `module get <uid>` - works correctly, retrieves specific module details
- `module config-bdb` - works with correct format: `{"modules": [{"module_name": "search", "module_args": "PARTITIONS AUTO"}]}`
- `module delete` - works correctly with force flag
- `module upload` - needs multipart/form-data implementation (tracked separately)

## Notes

- The upgrade-bdb endpoint is documented in the API but doesn't exist on actual instances
- The upload command needs to be updated to use multipart/form-data instead of JSON

Closes #153