### PR TITLE
docs: simplify README to focus on getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # redisctl
 
 [![Crates.io](https://img.shields.io/crates/v/redisctl.svg)](https://crates.io/crates/redisctl)
-[![Downloads](https://img.shields.io/crates/d/redisctl.svg)](https://crates.io/crates/redisctl)
 [![Documentation](https://docs.rs/redisctl/badge.svg)](https://docs.rs/redisctl)
-[![GitHub Release](https://img.shields.io/github/v/release/joshrotenberg/redisctl)](https://github.com/joshrotenberg/redisctl/releases)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/joshrotenberg/redisctl#license)
 [![CI](https://github.com/joshrotenberg/redisctl/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/redisctl/actions/workflows/ci.yml)
-[![Security Audit](https://github.com/joshrotenberg/redisctl/actions/workflows/security.yml/badge.svg)](https://github.com/joshrotenberg/redisctl/actions/workflows/security.yml)
-[![Docker](https://img.shields.io/docker/v/joshrotenberg/redisctl?label=docker)](https://hub.docker.com/r/joshrotenberg/redisctl)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/joshrotenberg/redisctl#license)
 
-A unified CLI for Redis Cloud and Redis Enterprise REST APIs with comprehensive async operation support.
+A unified command-line interface for managing Redis Cloud and Redis Enterprise deployments through their REST APIs.
 
 ## Features
 
@@ -17,204 +13,99 @@ A unified CLI for Redis Cloud and Redis Enterprise REST APIs with comprehensive 
 - **Async Operations** - Full support for long-running operations with `--wait` flags
 - **Smart Routing** - Automatically detects which API to use based on context
 - **Multiple Output Formats** - JSON, YAML, and Table output with JMESPath filtering
-- **Secure Configuration** - Profile-based auth with environment variable support
-- **Comprehensive Coverage** - Full API coverage for both platforms
+- **Profile Management** - Secure credential storage with environment variable support
 
 ## Installation
 
+### From Binary Releases
+Download the latest release for your platform from the [releases page](https://github.com/joshrotenberg/redisctl/releases).
+
+### From Cargo
 ```bash
-# Install from crates.io
 cargo install redisctl
-
-# Or build from source
-git clone https://github.com/joshrotenberg/redisctl.git
-cd redisctl
-cargo install --path crates/redisctl
 ```
 
-### Shell Completions
-
-`redisctl` can generate shell completions for various shells. To install them:
-
-#### Bash
+### Using Docker
 ```bash
-# Generate and install completion
-redisctl completions bash > ~/.local/share/bash-completion/completions/redisctl
-
-# Or for system-wide installation (requires sudo)
-redisctl completions bash | sudo tee /usr/share/bash-completion/completions/redisctl
-```
-
-#### Zsh
-```bash
-# Generate completion to a directory in your $fpath
-redisctl completions zsh > ~/.zsh/completions/_redisctl
-
-# Add this to your ~/.zshrc if not already present
-fpath=(~/.zsh/completions $fpath)
-autoload -U compinit && compinit
-```
-
-#### Fish
-```bash
-# Generate completion
-redisctl completions fish > ~/.config/fish/completions/redisctl.fish
-```
-
-#### PowerShell
-```powershell
-# Generate completion
-redisctl completions powershell > $PROFILE.CurrentUserAllHosts
-
-# Or add to your profile
-redisctl completions powershell >> $PROFILE
-```
-
-#### Elvish
-```bash
-# Generate completion
-redisctl completions elvish > ~/.elvish/lib/redisctl.elv
-
-# Add to rc.elv
-echo "use redisctl" >> ~/.elvish/rc.elv
+docker run --rm joshrotenberg/redisctl --help
 ```
 
 ## Quick Start
 
-### Configure Authentication
-
-Create `~/.config/redisctl/config.toml`:
-
-```toml
-[profiles.cloud]
-deployment_type = "cloud"
-api_key = "your-api-key"
-api_secret = "your-secret-key"
-
-[profiles.enterprise]
-deployment_type = "enterprise"
-url = "https://cluster:9443"
-username = "admin@example.com"
-password = "your-password"
-
-default_profile = "cloud"
-```
-
-Or use environment variables:
+### 1. Configure Authentication
 
 ```bash
 # Redis Cloud
-export REDIS_CLOUD_API_KEY="your-key"
-export REDIS_CLOUD_API_SECRET="your-secret"
+export REDIS_CLOUD_API_KEY="your-api-key"
+export REDIS_CLOUD_SECRET_KEY="your-secret-key"
 
 # Redis Enterprise
-export REDIS_ENTERPRISE_URL="https://cluster:9443"
-export REDIS_ENTERPRISE_USER="admin@example.com"
+export REDIS_ENTERPRISE_URL="https://your-cluster:9443"
+export REDIS_ENTERPRISE_USER="your-email@example.com"
 export REDIS_ENTERPRISE_PASSWORD="your-password"
 ```
 
-### Basic Usage
-
-### Database Operations
+Or use profiles for multiple environments:
 
 ```bash
-# List databases
+# Create a profile
+redisctl profile set cloud-prod \
+  --cloud-api-key="$REDIS_CLOUD_API_KEY" \
+  --cloud-secret-key="$REDIS_CLOUD_SECRET_KEY"
+
+# Use the profile
+redisctl --profile cloud-prod cloud database list
+```
+
+### 2. Basic Commands
+
+```bash
+# List databases (auto-detects deployment type from profile)
 redisctl database list
 
-# Create database with async wait
+# Get database details with formatted output
+redisctl database get 12345 --output table
+
+# Create a database and wait for completion
 redisctl cloud database create --data @database.json --wait
 
-# Update database with wait
-redisctl cloud database update 12345 --data @update.json --wait
-
-# Different output formats with filtering
-redisctl database list -o yaml | yq '.[] | select(.name == "prod")'
-
-# Delete database with force and wait
-redisctl cloud database delete 12345 --force --wait
+# Direct API access for any endpoint
+redisctl api cloud get /subscriptions/88449/databases
 ```
-
-## Output Formats
-
-```bash
-# JSON output (default)
-redisctl database list -o json
-
-# YAML output
-redisctl database list -o yaml
-
-# Human-readable table
-redisctl database list -o table
-
-# Filter with JMESPath
-redisctl database list -q "[?status=='active'].{name: name, memory: memoryLimitInGb}"
-
-# Combine with jq for advanced processing
-redisctl database list -o json | jq '.[] | select(.name | contains("prod"))'
-```
-
-## Profile Management
-
-```bash
-# List all profiles
-redisctl profile list
-
-# Set default profile
-redisctl profile default cloud-prod
-
-# Get specific profile settings
-redisctl profile get enterprise-dev
-
-# Set profile values
-redisctl profile set cloud-staging api_key "new-key"
-redisctl profile set cloud-staging api_secret "new-secret"
-
-# Remove profile
-redisctl profile remove old-profile
-
-# Use specific profile for a command
-redisctl database list --profile cloud-staging
-```
-
-## Environment Variables
-
-### Cloud Configuration
-- `REDIS_CLOUD_API_KEY` - API key for authentication
-- `REDIS_CLOUD_API_SECRET` - API secret for authentication
-- `REDIS_CLOUD_API_URL` - Custom API URL (optional)
-
-### Enterprise Configuration
-- `REDIS_ENTERPRISE_URL` - Cluster API URL
-- `REDIS_ENTERPRISE_USER` - Username for authentication
-- `REDIS_ENTERPRISE_PASSWORD` - Password for authentication
-- `REDIS_ENTERPRISE_INSECURE` - Allow insecure TLS (true/false)
-
-### General Configuration
-- `REDISCTL_PROFILE` - Default profile to use
-- `RUST_LOG` - Logging level (error, warn, info, debug, trace)
 
 ## Documentation
 
-For comprehensive documentation, see the [mdBook documentation](docs/):
+For comprehensive documentation including:
+- Detailed configuration options
+- Complete command reference
+- Async operation handling
+- Output formatting and filtering
+- Troubleshooting guides
 
-- [Getting Started](docs/src/getting-started/index.md) - Installation and configuration
-- [CLI Reference](docs/src/cli-reference/index.md) - Complete command reference
-- [Async Operations](docs/src/features/async-operations.md) - Using `--wait` flags  
-- [Examples](docs/src/examples/index.md) - Common use cases and patterns
-- **API Reference** - Complete command reference
+Visit the [full documentation](https://joshrotenberg.github.io/redisctl/).
 
 ## Development
 
-This project provides Rust client libraries for both APIs:
-
-```toml
-[dependencies]
-redis-cloud = "0.2"       # Redis Cloud API client
-redis-enterprise = "0.2"  # Redis Enterprise API client
+### Building from Source
+```bash
+git clone https://github.com/joshrotenberg/redisctl.git
+cd redisctl
+cargo build --release
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
+### Running Tests
+```bash
+cargo test --workspace
+```
+
+## Contributing
+
+Contributions are welcome! Please see the [contributing guidelines](https://joshrotenberg.github.io/redisctl/developer/contributing.html) in the documentation.
 
 ## License
 
-This project is licensed under the MIT License - see [LICENSE](LICENSE) file for details.
+Licensed under either of:
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,8 +1,33 @@
 # Installation
 
-## From Source
+## Binary Releases
+
+Download the latest release for your platform from the [GitHub releases page](https://github.com/joshrotenberg/redisctl/releases).
+
+### Linux/macOS
+```bash
+# Download the binary (replace VERSION and PLATFORM)
+curl -L https://github.com/joshrotenberg/redisctl/releases/download/vVERSION/redisctl-PLATFORM.tar.gz | tar xz
+
+# Move to PATH
+sudo mv redisctl /usr/local/bin/
+
+# Make executable
+chmod +x /usr/local/bin/redisctl
+```
+
+### Windows
+Download the `.zip` file from the releases page and extract to a directory in your PATH.
+
+## From Cargo
 
 If you have Rust installed:
+
+```bash
+cargo install redisctl
+```
+
+## From Source
 
 ```bash
 git clone https://github.com/joshrotenberg/redisctl.git
@@ -10,18 +35,74 @@ cd redisctl
 cargo install --path crates/redisctl
 ```
 
-## Pre-built Binaries
-
-Coming soon - binaries will be available for:
-- Linux (x86_64, ARM64)
-- macOS (Intel, Apple Silicon)
-- Windows
-
 ## Docker
 
 ```bash
-docker pull redisctl/redisctl:latest
-docker run redisctl/redisctl --help
+# Pull the image
+docker pull joshrotenberg/redisctl:latest
+
+# Run commands
+docker run --rm joshrotenberg/redisctl --help
+
+# With environment variables
+docker run --rm \
+  -e REDIS_CLOUD_API_KEY="your-key" \
+  -e REDIS_CLOUD_SECRET_KEY="your-secret" \
+  joshrotenberg/redisctl cloud database list
+```
+
+## Shell Completions
+
+`redisctl` can generate shell completions for better command-line experience.
+
+### Bash
+```bash
+# Generate completion
+redisctl completions bash > ~/.local/share/bash-completion/completions/redisctl
+
+# Or system-wide (requires sudo)
+redisctl completions bash | sudo tee /usr/share/bash-completion/completions/redisctl
+
+# Reload your shell or source the completion
+source ~/.local/share/bash-completion/completions/redisctl
+```
+
+### Zsh
+```bash
+# Add to your fpath (usually in ~/.zshrc)
+redisctl completions zsh > ~/.zsh/completions/_redisctl
+
+# Or use oh-my-zsh custom completions
+redisctl completions zsh > ~/.oh-my-zsh/custom/completions/_redisctl
+
+# Reload shell
+exec zsh
+```
+
+### Fish
+```bash
+# Generate completion
+redisctl completions fish > ~/.config/fish/completions/redisctl.fish
+
+# Completions are loaded automatically
+```
+
+### PowerShell
+```powershell
+# Generate completion
+redisctl completions powershell | Out-String | Invoke-Expression
+
+# To make permanent, add to your PowerShell profile
+redisctl completions powershell >> $PROFILE
+```
+
+### Elvish
+```bash
+# Generate completion
+redisctl completions elvish > ~/.config/elvish/lib/redisctl.elv
+
+# Add to rc.elv
+echo "use redisctl" >> ~/.config/elvish/rc.elv
 ```
 
 ## Verify Installation
@@ -30,6 +111,19 @@ docker run redisctl/redisctl --help
 redisctl --version
 ```
 
+## Platform-Specific Binaries
+
+For specific deployment scenarios, you can build platform-specific binaries:
+
+```bash
+# Cloud-only binary (smaller size)
+cargo build --release --features cloud-only --bin redis-cloud
+
+# Enterprise-only binary
+cargo build --release --features enterprise-only --bin redis-enterprise
+```
+
 ## Next Steps
 
 - [Configuration](./configuration.md) - Set up your credentials
+- [Quick Start](./quickstart.md) - Run your first commands


### PR DESCRIPTION
## Summary
Simplifies the README to be a concise entry point that gets users started quickly.

Part of #243 and resolves #244

## Changes
- Reduced README from 219 to 110 lines (50% reduction)
- Focused on essential information only:
  - Brief description
  - Key features (5 bullets)
  - Installation options
  - Quick start examples
  - Link to full documentation
- Moved detailed content to documentation site:
  - Shell completions → installation guide
  - Detailed configuration → docs
  - All examples → docs

## Before/After
- **Before**: 219 lines with detailed instructions for everything
- **After**: 110 lines with just enough to get started

## Impact
- New users can install and run their first command in under 2 minutes
- README serves as a gateway to comprehensive documentation
- Reduces maintenance burden (single source of truth in docs)

## Testing
- [x] All links in README work
- [x] Installation instructions are accurate
- [x] Quick start examples are tested and working
- [x] Documentation site contains all removed content