### PR TITLE
feat: add profile path command and improve config visibility

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -154,6 +154,9 @@ pub enum ProfileCommands {
     #[command(visible_alias = "ls", visible_alias = "l")]
     List,
 
+    /// Show the path to the configuration file
+    Path,
+
     /// Show details of a specific profile
     #[command(visible_alias = "sh", visible_alias = "get")]
     Show {


### PR DESCRIPTION
## Summary
Makes profile configuration more discoverable by showing users where their config files are stored.

Addresses #251

## Changes
- ✨ Added `profile path` command to show config file location
- 📍 `profile list` now shows config file path at the top
- 💾 `profile set` shows where the config was saved

## Examples

### New `profile path` command
```bash
$ redisctl profile path
/Users/username/.config/redisctl/config.toml
```

### Enhanced `profile list` output
```bash
$ redisctl profile list
Configuration file: /Users/username/.config/redisctl/config.toml

NAME            TYPE         DETAILS
--------------- ------------ ------------------------------
cloud-prod*     cloud        URL: https://api.redislabs.com/v1
enterprise-dev  enterprise   URL: https://localhost:9443, User: admin@cluster.local (insecure)
```

### Improved `profile set` feedback
```bash
$ redisctl profile set test-profile --deployment cloud --api-key xxx --api-secret yyy
Profile 'test-profile' saved successfully to:
  /Users/username/.config/redisctl/config.toml
Set 'test-profile' as the default profile? (Y/n):
```

## Impact
- Users can easily find their config file for manual editing or backup
- Reduces confusion about where profiles are stored
- Makes troubleshooting easier

## Testing
- [x] `profile path` command works
- [x] `profile list` shows config path
- [x] `profile set` shows save location
- [x] All tests pass