### PR TITLE
feat: add automatic Docker Hub README sync

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,3 +63,12 @@ jobs:
             ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Update Docker Hub README
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: joshrotenberg/redisctl
+          readme-filepath: ./README.md
+          short-description: "Unified CLI for Redis Cloud and Redis Enterprise management"


### PR DESCRIPTION
## Summary

This PR adds automatic syncing of the README to Docker Hub whenever we create a new release.

## Problem
As noted in #285, the Docker Hub README was outdated and had to be manually updated. This creates extra work and can lead to users seeing stale documentation.

## Solution
Added the `peter-evans/dockerhub-description` GitHub Action to the Docker workflow. This action will:
- Automatically sync the main README.md to Docker Hub after building and pushing images
- Update the short description
- Run on every release (triggered by version tags)

## Changes
- Added new step to `.github/workflows/docker.yml`
- Uses existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets (already configured)
- Syncs `README.md` to Docker Hub repository description

## Testing
This will be tested on the next release. The action is well-maintained and widely used in the community.

## Benefits
- No more manual README updates on Docker Hub
- Users always see current documentation
- Consistent information across all distribution channels
- Zero additional maintenance required

Closes #285