### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,8 +18,8 @@ path = "src/main.rs"
 
 
 [dependencies]
-redis-cloud = { version = "0.4.1", path = "../redis-cloud" }
-redis-enterprise = { version = "0.4.1", path = "../redis-enterprise" }
+redis-cloud = { version = "0.5.0", path = "../redis-cloud" }
+redis-enterprise = { version = "0.5.0", path = "../redis-enterprise" }
 
 # CLI dependencies
 clap = { workspace = true }


### PR DESCRIPTION
## Release v0.5.0

This PR bumps the version to v0.5.0 for release.

## What's Changed

### New Features
- feat(enterprise): add comprehensive alerts management commands (#307)
- feat(enterprise): add license management commands (#308) 
- feat(enterprise): implement bootstrap commands for cluster initialization (#309)
- feat(enterprise): add debug info collection commands (#309)
- feat(enterprise): implement LDAP integration commands (#309)
- feat(enterprise): add OCSP certificate validation commands (#309)
- feat(enterprise): implement service management commands (#309)

### Improvements
- chore: simplify crates.io publishing workflow and remove manual release scripts (#310)
- docs: add comprehensive documentation for all new enterprise commands (#310)
- chore: update CLAUDE.md with documentation requirements for new features (#310)

### Coverage
- Enterprise API coverage increased to 74% (29 handlers implemented)
- All new commands include comprehensive integration tests with wiremock

### Breaking Changes
None

## Release Process
After merging this PR:
1. Checkout main and pull latest
2. Create and push tag: `git tag v0.5.0 && git push origin v0.5.0`
3. Automated workflows will:
   - Build binaries for all platforms (cargo-dist)
   - Create GitHub Release with artifacts
   - Publish Docker images to Docker Hub
   - Publish crates to crates.io

### Full Changelog
https://github.com/joshrotenberg/redisctl/compare/v0.4.1...v0.5.0