### PR TITLE
fix: add workflow_dispatch trigger to crates publish workflow

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -3,6 +3,7 @@ name: Publish to crates.io
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem
The crates.io publish workflow didn't trigger for the v0.5.0 release.

## Root Cause
When GitHub Actions creates a release using GITHUB_TOKEN (which cargo-dist does), it doesn't trigger other workflows' `release:published` events to prevent infinite loops. This is documented GitHub behavior.

## Solution
Add `workflow_dispatch` as an additional trigger to allow manual publishing when the automatic trigger doesn't fire.

## Changes
- Added `workflow_dispatch` trigger to publish-crates.yml
- This allows manual triggering via GitHub UI or CLI

## Testing
After merging, we can manually trigger the workflow to publish v0.5.0 to crates.io.