### PR TITLE
fix(enterprise): use correct endpoint for services list command

### DIFF
--- a/crates/redisctl/src/commands/enterprise/services.rs
+++ b/crates/redisctl/src/commands/enterprise/services.rs
@@ -101,8 +101,9 @@ async fn handle_services_list(
 ) -> Result<(), RedisCtlError> {
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
 
+    // Use /v1/local/services endpoint - /v1/services doesn't exist for GET
     let response = client
-        .get::<Value>("/v1/services")
+        .get::<Value>("/v1/local/services")
         .await
         .context("Failed to list services")?;
 


### PR DESCRIPTION
## Summary
This PR fixes the `enterprise services list` command which was using an incorrect endpoint.

## Problem
The command was trying to use `/v1/services` which doesn't exist for GET requests. This caused the error:
```
Configuration error: Failed to list services
```

## Solution
Changed to use `/v1/local/services` which is the correct documented endpoint.

## Changes
- Updated `handle_services_list` in `services.rs` to use `/v1/local/services` instead of `/v1/services`

## Testing
Tested against live Redis Enterprise cluster:
```bash
REDIS_ENTERPRISE_URL="https://localhost:9443" \
REDIS_ENTERPRISE_USER="admin@cluster.local" \
REDIS_ENTERPRISE_PASSWORD="Redis123!" \
REDIS_ENTERPRISE_INSECURE="true" \
cargo run --bin redisctl -- enterprise services list
```

Successfully returns list of services and their status.

## Fixes
- Fixes #322