### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.6.0

### ✨ New Features
- **Support Package Commands**: New dedicated `enterprise support-package` command group for generating Redis Enterprise support packages with improved UX
  - Smart file naming with timestamps
  - JSON output for CI/CD automation
  - Pre-flight checks for disk space and permissions
  - Commands for cluster, database, and node-specific packages

### 🔧 Improvements
- Binary download support for debug-info endpoints
- More resilient environment variable handling in config files
- Better documentation for support package workflows

This release makes generating support packages significantly easier for Redis Enterprise operators.