### PR TITLE
feat: add workflow_dispatch to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 env:
   REGISTRY: docker.io
@@ -23,7 +24,16 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual dispatch, use the current ref name or latest tag
+            if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+              VERSION=${GITHUB_REF#refs/tags/v}
+            else
+              VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+            fi
+          else
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "major=$(echo $VERSION | cut -d. -f1)" >> $GITHUB_OUTPUT
           echo "minor=$(echo $VERSION | cut -d. -f1-2)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
Adds `workflow_dispatch` trigger to the Docker workflow to allow manual triggering of Docker image builds.

## Problem
The Docker workflow for v0.6.1 didn't trigger automatically when the tag was pushed. This happens occasionally with GitHub Actions when tags are pushed after the commit is already on the remote.

## Solution
- Added `workflow_dispatch` event trigger to allow manual Docker builds
- Updated version extraction logic to handle both tag pushes and manual dispatches
- For manual dispatch on non-tag refs, uses the latest tag version

## Testing
Once merged, we can manually trigger the Docker build for v0.6.1 and future releases if automatic triggers fail.

## Related
- The publish-crates workflow already has `workflow_dispatch` which allowed us to manually publish v0.6.1 to crates.io
- This change brings the Docker workflow to parity