### PR TITLE
fix: Docker workflow version extraction for manual dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Extract version
         id: version
@@ -34,6 +37,7 @@ jobs:
           else
             VERSION=${GITHUB_REF#refs/tags/v}
           fi
+          echo "Extracted version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "major=$(echo $VERSION | cut -d. -f1)" >> $GITHUB_OUTPUT
           echo "minor=$(echo $VERSION | cut -d. -f1-2)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem
The Docker workflow failed when manually triggered from main branch with:
```
buildx failed with: ERROR: failed to build: invalid tag "***/redisctl:": invalid reference format
```

The version extraction was returning an empty string because `git describe --tags` couldn't find tags (shallow clone).

## Solution
1. Added `fetch-depth: 0` and `fetch-tags: true` to checkout action to ensure all tags are available
2. Added debug output to show the extracted version for troubleshooting

## Testing
After this fix, manual dispatch from main branch will correctly extract version `0.6.1` and build/push Docker images with proper tags.

## Related
- Follow-up to #358 which added workflow_dispatch support
- Needed to publish Docker images for v0.6.1 release