### PR TITLE
feat: add secure credential storage using OS keyring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2062,7 @@ dependencies = [
  "directories",
  "indicatif",
  "jmespath",
+ "keyring",
  "pager",
  "predicates",
  "redis-cloud",

--- a/README.md
+++ b/README.md
@@ -48,18 +48,53 @@ export REDIS_ENTERPRISE_PASSWORD="your-password"
 Or use profiles for multiple environments:
 
 ```bash
-# Create a profile
+# Create a profile with plaintext storage (default)
 redisctl profile set cloud-prod \
-  --cloud-api-key="$REDIS_CLOUD_API_KEY" \
-  --cloud-secret-key="$REDIS_CLOUD_SECRET_KEY"
+  --deployment cloud \
+  --api-key "$REDIS_CLOUD_API_KEY" \
+  --api-secret "$REDIS_CLOUD_SECRET_KEY"
+
+# Create a profile with secure OS keyring storage (recommended)
+redisctl profile set cloud-secure \
+  --deployment cloud \
+  --api-key "$REDIS_CLOUD_API_KEY" \
+  --api-secret "$REDIS_CLOUD_SECRET_KEY" \
+  --use-keyring  # Requires 'secure-storage' feature
 
 # Use the profile
 redisctl --profile cloud-prod cloud database list
 ```
 
+### Profile Storage
+
 Profiles are stored in:
 - **Linux/macOS**: `~/.config/redisctl/config.toml`
 - **Windows**: `%APPDATA%\redis\redisctl\config.toml`
+
+### Secure Credential Storage
+
+When compiled with the `secure-storage` feature, redisctl can store sensitive credentials in your OS keyring:
+
+- **macOS**: Keychain
+- **Windows**: Windows Credential Store
+- **Linux**: Secret Service (GNOME Keyring, KWallet)
+
+To use secure storage:
+```bash
+# Install with secure storage support
+cargo install redisctl --features secure-storage
+
+# Create profile with keyring storage
+redisctl profile set prod \
+  --deployment cloud \
+  --api-key "your-key" \
+  --api-secret "your-secret" \
+  --use-keyring
+
+# The config file will contain references like:
+# api_key = "keyring:prod-api-key"
+# api_secret = "keyring:prod-api-secret"
+```
 
 Example configuration file:
 ```toml

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -49,6 +49,9 @@ toml = { workspace = true }
 directories = { workspace = true }
 shellexpand = "3.1"
 
+# Secure storage
+keyring = { version = "3.6", optional = true }
+
 [target.'cfg(unix)'.dependencies]
 pager = "0.16"
 
@@ -58,6 +61,7 @@ default = ["full"]
 full = ["cloud", "enterprise"]
 cloud = []
 enterprise = []
+secure-storage = ["dep:keyring"]
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -201,6 +201,11 @@ pub enum ProfileCommands {
         /// Allow insecure connections (for Enterprise profiles)
         #[arg(long)]
         insecure: bool,
+
+        /// Store credentials in OS keyring instead of config file
+        #[cfg(feature = "secure-storage")]
+        #[arg(long)]
+        use_keyring: bool,
     },
 
     /// Remove a profile

--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -73,8 +73,10 @@ impl ConnectionManager {
                     });
                 }
 
+                // Use the new resolve method which handles keyring lookup
                 let (api_key, api_secret, api_url) = profile
-                    .cloud_credentials()
+                    .resolve_cloud_credentials()
+                    .context("Failed to resolve Cloud credentials")?
                     .context("Profile is not configured for Redis Cloud")?;
 
                 // Check for partial overrides before consuming the Options
@@ -82,9 +84,9 @@ impl ConnectionManager {
                     env_api_key.is_some() || env_api_secret.is_some() || env_api_url.is_some();
 
                 // Allow partial environment variable overrides
-                let key = env_api_key.unwrap_or_else(|| api_key.to_string());
-                let secret = env_api_secret.unwrap_or_else(|| api_secret.to_string());
-                let url = env_api_url.unwrap_or_else(|| api_url.to_string());
+                let key = env_api_key.unwrap_or(api_key);
+                let secret = env_api_secret.unwrap_or(api_secret);
+                let url = env_api_url.unwrap_or(api_url);
 
                 if has_overrides {
                     debug!("Applied partial environment variable overrides");
@@ -173,8 +175,10 @@ impl ConnectionManager {
                     });
                 }
 
+                // Use the new resolve method which handles keyring lookup
                 let (url, username, password, insecure) = profile
-                    .enterprise_credentials()
+                    .resolve_enterprise_credentials()
+                    .context("Failed to resolve Enterprise credentials")?
                     .context("Profile is not configured for Redis Enterprise")?;
 
                 // Check for partial overrides before consuming the Options
@@ -184,9 +188,9 @@ impl ConnectionManager {
                     || env_insecure.is_some();
 
                 // Allow partial environment variable overrides
-                let final_url = env_url.unwrap_or_else(|| url.to_string());
-                let final_user = env_user.unwrap_or_else(|| username.to_string());
-                let final_password = env_password.or_else(|| password.map(|p| p.to_string()));
+                let final_url = env_url.unwrap_or(url);
+                let final_user = env_user.unwrap_or(username);
+                let final_password = env_password.or(password);
                 let final_insecure = env_insecure
                     .as_ref()
                     .map(|s| s.to_lowercase() == "true" || s == "1")

--- a/crates/redisctl/src/credential_store.rs
+++ b/crates/redisctl/src/credential_store.rs
@@ -1,0 +1,246 @@
+//! Credential storage abstraction with optional keyring support
+//!
+//! This module provides a unified interface for storing and retrieving credentials,
+//! with support for:
+//! - OS keyring (when feature enabled)
+//! - Plaintext storage (fallback)
+//! - Environment variable override
+
+use anyhow::{Context, Result};
+use std::env;
+
+/// Prefix that indicates a value should be retrieved from the keyring
+const KEYRING_PREFIX: &str = "keyring:";
+
+/// Service name for keyring entries
+const SERVICE_NAME: &str = "redisctl";
+
+/// Storage backend for credentials
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum CredentialStorage {
+    /// Store in OS keyring
+    #[cfg(feature = "secure-storage")]
+    Keyring,
+    /// Store as plaintext
+    Plaintext,
+}
+
+/// Credential store abstraction
+pub struct CredentialStore {
+    #[allow(dead_code)]
+    storage: CredentialStorage,
+}
+
+impl Default for CredentialStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CredentialStore {
+    /// Create a new credential store with automatic backend selection
+    pub fn new() -> Self {
+        #[cfg(feature = "secure-storage")]
+        {
+            // Try to use keyring if available
+            if Self::is_keyring_available() {
+                Self {
+                    storage: CredentialStorage::Keyring,
+                }
+            } else {
+                Self {
+                    storage: CredentialStorage::Plaintext,
+                }
+            }
+        }
+        #[cfg(not(feature = "secure-storage"))]
+        {
+            Self {
+                storage: CredentialStorage::Plaintext,
+            }
+        }
+    }
+
+    /// Check if keyring is available on this system
+    #[cfg(feature = "secure-storage")]
+    fn is_keyring_available() -> bool {
+        // Try to create a test entry to see if keyring works
+        match keyring::Entry::new(SERVICE_NAME, "__test__") {
+            Ok(entry) => {
+                // Try to get a non-existent password (should fail gracefully)
+                let _ = entry.get_password();
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Store a credential value
+    #[allow(dead_code)]
+    pub fn store_credential(&self, key: &str, value: &str) -> Result<String> {
+        #[cfg(feature = "secure-storage")]
+        {
+            match self.storage {
+                CredentialStorage::Keyring => {
+                    let entry = keyring::Entry::new(SERVICE_NAME, key)
+                        .context("Failed to create keyring entry")?;
+                    entry
+                        .set_password(value)
+                        .context("Failed to store credential in keyring")?;
+                    // Return the reference string that will be stored in config
+                    Ok(format!("{}{}", KEYRING_PREFIX, key))
+                }
+                CredentialStorage::Plaintext => Ok(value.to_string()),
+            }
+        }
+        #[cfg(not(feature = "secure-storage"))]
+        {
+            // Without secure-storage feature, always use plaintext
+            Ok(value.to_string())
+        }
+    }
+
+    /// Retrieve a credential value
+    ///
+    /// Resolution order:
+    /// 1. Check environment variable (if env_var provided)
+    /// 2. If value starts with "keyring:", retrieve from keyring
+    /// 3. Otherwise, return the value as-is (plaintext)
+    pub fn get_credential(&self, value: &str, env_var: Option<&str>) -> Result<String> {
+        // First check environment variable if provided
+        if let Some(var) = env_var
+            && let Ok(env_value) = env::var(var)
+        {
+            return Ok(env_value);
+        }
+
+        // Check if this is a keyring reference
+        if value.starts_with(KEYRING_PREFIX) {
+            #[cfg(feature = "secure-storage")]
+            {
+                let key = value.trim_start_matches(KEYRING_PREFIX);
+                let entry = keyring::Entry::new(SERVICE_NAME, key)
+                    .context("Failed to create keyring entry")?;
+                entry.get_password().with_context(|| {
+                    format!("Failed to retrieve credential '{}' from keyring", key)
+                })
+            }
+            #[cfg(not(feature = "secure-storage"))]
+            {
+                anyhow::bail!(
+                    "Credential references keyring but secure-storage feature is not enabled"
+                )
+            }
+        } else {
+            // Plain text value
+            Ok(value.to_string())
+        }
+    }
+
+    /// Delete a credential from storage
+    #[allow(dead_code)]
+    pub fn delete_credential(&self, key: &str) -> Result<()> {
+        #[cfg(feature = "secure-storage")]
+        {
+            match self.storage {
+                CredentialStorage::Keyring => {
+                    let entry = keyring::Entry::new(SERVICE_NAME, key)
+                        .context("Failed to create keyring entry")?;
+                    match entry.delete_credential() {
+                        Ok(()) => Ok(()),
+                        Err(keyring::Error::NoEntry) => Ok(()), // Already deleted
+                        Err(e) => Err(e).context("Failed to delete credential from keyring"),
+                    }
+                }
+                CredentialStorage::Plaintext => Ok(()), // Nothing to delete for plaintext
+            }
+        }
+        #[cfg(not(feature = "secure-storage"))]
+        {
+            Ok(()) // Nothing to delete for plaintext
+        }
+    }
+
+    /// Check if a value is a keyring reference
+    #[allow(dead_code)]
+    pub fn is_keyring_reference(value: &str) -> bool {
+        value.starts_with(KEYRING_PREFIX)
+    }
+
+    /// Get the current storage backend
+    #[allow(dead_code)]
+    pub fn storage_backend(&self) -> &str {
+        #[cfg(feature = "secure-storage")]
+        {
+            match self.storage {
+                CredentialStorage::Keyring => "keyring",
+                CredentialStorage::Plaintext => "plaintext",
+            }
+        }
+        #[cfg(not(feature = "secure-storage"))]
+        {
+            "plaintext"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plaintext_storage() {
+        let store = CredentialStore::new();
+
+        // Plaintext values should be returned as-is
+        let result = store.get_credential("my-api-key", None).unwrap();
+        assert_eq!(result, "my-api-key");
+    }
+
+    #[test]
+    fn test_env_var_override() {
+        unsafe {
+            env::set_var("TEST_CREDENTIAL", "env-value");
+        }
+
+        let store = CredentialStore::new();
+        let result = store
+            .get_credential("config-value", Some("TEST_CREDENTIAL"))
+            .unwrap();
+        assert_eq!(result, "env-value");
+
+        unsafe {
+            env::remove_var("TEST_CREDENTIAL");
+        }
+    }
+
+    #[test]
+    fn test_keyring_reference_detection() {
+        assert!(CredentialStore::is_keyring_reference("keyring:my-key"));
+        assert!(!CredentialStore::is_keyring_reference("my-key"));
+        assert!(!CredentialStore::is_keyring_reference(""));
+    }
+
+    #[cfg(feature = "secure-storage")]
+    #[test]
+    #[ignore = "Requires keyring service to be available"]
+    fn test_keyring_storage() {
+        let store = CredentialStore::new();
+
+        // Store a credential
+        let key = "test-credential";
+        let value = "test-value";
+        let reference = store.store_credential(key, value).unwrap();
+
+        // Should return a keyring reference
+        assert!(reference.starts_with(KEYRING_PREFIX));
+
+        // Retrieve it back
+        let retrieved = store.get_credential(&reference, None).unwrap();
+        assert_eq!(retrieved, value);
+
+        // Clean up
+        let _ = store.delete_credential(key);
+    }
+}

--- a/crates/redisctl/src/lib.rs
+++ b/crates/redisctl/src/lib.rs
@@ -85,6 +85,7 @@ pub(crate) mod cli;
 pub(crate) mod commands;
 pub(crate) mod config;
 pub(crate) mod connection;
+pub(crate) mod credential_store;
 pub(crate) mod error;
 pub(crate) mod output;
 pub(crate) mod workflows;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -78,6 +78,7 @@
 
 - [Environment Variables](./reference/environment-variables.md)
 - [Configuration File](./reference/config-file.md)
+- [Security Best Practices](./reference/security.md)
 - [Troubleshooting](./reference/troubleshooting.md)
 - [Best Practices](./reference/best-practices.md)
 - [API Reference](./reference/api.md)

--- a/docs/src/getting-started/authentication.md
+++ b/docs/src/getting-started/authentication.md
@@ -17,7 +17,36 @@ Redis Cloud uses API key authentication:
 
 ### Setting Up Authentication
 
-Use environment variables:
+#### Option 1: Secure OS Keyring (Recommended)
+
+When compiled with the `secure-storage` feature, store credentials securely in your OS keyring:
+
+```bash
+# Install with secure storage support
+cargo install redisctl --features secure-storage
+
+# Create secure profile
+redisctl profile set cloud \
+  --deployment cloud \
+  --api-key "your-account-key" \
+  --api-secret "your-secret-key" \
+  --use-keyring  # Stores in OS keyring
+
+# Test it works
+redisctl --profile cloud api cloud get /
+```
+
+Your config will contain secure references:
+```toml
+[profiles.cloud]
+deployment_type = "cloud"
+api_key = "keyring:cloud-api-key"      # Actual value in OS keyring
+api_secret = "keyring:cloud-api-secret" # Actual value in OS keyring
+```
+
+#### Option 2: Environment Variables
+
+Use environment variables (good for CI/CD):
 
 ```bash
 export REDIS_CLOUD_API_KEY="your-account-key"
@@ -27,7 +56,9 @@ export REDIS_CLOUD_API_SECRET="your-secret-key"
 redisctl api cloud get /
 ```
 
-Or create a configuration file at `~/.config/redisctl/config.toml`:
+#### Option 3: Configuration File (Development Only)
+
+For development only, you can use plaintext config at `~/.config/redisctl/config.toml`:
 
 ```toml
 [profiles.cloud]
@@ -35,6 +66,8 @@ deployment_type = "cloud"
 api_key = "your-account-key"
 api_secret = "your-secret-key"
 ```
+
+⚠️ **Warning**: This stores credentials in plaintext. Use keyring or environment variables for production!
 
 ## Redis Enterprise
 
@@ -46,6 +79,38 @@ Redis Enterprise uses basic authentication with username/password.
 - **Password**: Set during cluster setup
 
 ### Setting Up Authentication
+
+#### Option 1: Secure OS Keyring (Recommended)
+
+Store credentials securely in your OS keyring:
+
+```bash
+# Create secure profile
+redisctl profile set enterprise \
+  --deployment enterprise \
+  --url "https://cluster.example.com:9443" \
+  --username "admin@cluster.local" \
+  --password "your-password" \
+  --use-keyring  # Stores in OS keyring
+
+# For self-signed certificates
+redisctl profile set enterprise --insecure true
+
+# Test it works
+redisctl --profile enterprise api enterprise get /v1/cluster
+```
+
+Your config will contain secure references:
+```toml
+[profiles.enterprise]
+deployment_type = "enterprise"
+url = "https://cluster.example.com:9443"
+username = "keyring:enterprise-username"  # Actual value in OS keyring
+password = "keyring:enterprise-password"  # Actual value in OS keyring
+insecure = false
+```
+
+#### Option 2: Environment Variables
 
 Use environment variables:
 
@@ -61,7 +126,9 @@ export REDIS_ENTERPRISE_INSECURE="true"
 redisctl api enterprise get /v1/cluster
 ```
 
-Or add to `~/.config/redisctl/config.toml`:
+#### Option 3: Configuration File (Development Only)
+
+For development only, add to `~/.config/redisctl/config.toml`:
 
 ```toml
 [profiles.enterprise]
@@ -71,6 +138,8 @@ username = "admin@cluster.local"
 password = "your-password"
 insecure = true  # For self-signed certs
 ```
+
+⚠️ **Warning**: This stores credentials in plaintext. Use keyring or environment variables for production!
 
 ## Security Tips
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -24,15 +24,35 @@ Download the `.zip` file from the releases page and extract to a directory in yo
 If you have Rust installed:
 
 ```bash
+# Basic installation
 cargo install redisctl
+
+# With secure credential storage support (recommended)
+cargo install redisctl --features secure-storage
 ```
+
+### Feature Flags
+
+| Feature | Description |
+|---------|-------------|
+| `secure-storage` | Enables OS keyring support for secure credential storage (recommended) |
+| `cloud-only` | Builds only Cloud functionality (smaller binary) |
+| `enterprise-only` | Builds only Enterprise functionality (smaller binary) |
 
 ## From Source
 
 ```bash
 git clone https://github.com/joshrotenberg/redisctl.git
 cd redisctl
+
+# Basic installation
 cargo install --path crates/redisctl
+
+# With secure storage support (recommended)
+cargo install --path crates/redisctl --features secure-storage
+
+# Development build with all features
+cargo build --release --all-features
 ```
 
 ## Docker

--- a/docs/src/reference/security.md
+++ b/docs/src/reference/security.md
@@ -1,0 +1,285 @@
+# Security Best Practices
+
+This guide covers security best practices for using redisctl in production environments.
+
+## Credential Storage
+
+### Storage Methods Comparison
+
+| Method | Security Level | Use Case | Pros | Cons |
+|--------|---------------|----------|------|------|
+| OS Keyring | ⭐⭐⭐⭐⭐ High | Production | Encrypted by OS, Most secure | Requires `secure-storage` feature |
+| Environment Variables | ⭐⭐⭐⭐ Good | CI/CD, Containers | No file storage, Easy rotation | Must be set each session |
+| Config File (Plaintext) | ⭐⭐ Low | Development only | Simple setup | Credentials visible in file |
+
+### Using OS Keyring (Recommended for Production)
+
+The most secure way to store credentials is using your operating system's keyring:
+
+```bash
+# Install with secure storage support
+cargo install redisctl --features secure-storage
+
+# Create secure profile
+redisctl profile set production \
+  --deployment cloud \
+  --api-key "your-api-key" \
+  --api-secret "your-api-secret" \
+  --use-keyring
+```
+
+#### Platform Support
+- **macOS**: Uses Keychain (automatic)
+- **Windows**: Uses Credential Manager (automatic)
+- **Linux**: Uses Secret Service (requires GNOME Keyring or KWallet)
+
+#### How Keyring Storage Works
+
+1. **Initial Setup**: When you use `--use-keyring`, credentials are stored in the OS keyring
+2. **Config Reference**: The config file stores references like `keyring:production-api-key`
+3. **Automatic Retrieval**: redisctl automatically retrieves credentials from keyring when needed
+4. **Secure Updates**: Credentials can be updated without exposing them in files
+
+Example config with keyring references:
+```toml
+[profiles.production]
+deployment_type = "cloud"
+api_key = "keyring:production-api-key"      # Actual value in keyring
+api_secret = "keyring:production-api-secret" # Actual value in keyring
+api_url = "https://api.redislabs.com/v1"    # Non-sensitive, plaintext
+```
+
+### Environment Variables (CI/CD)
+
+For automated environments, use environment variables:
+
+```bash
+# Set credentials
+export REDIS_CLOUD_API_KEY="your-key"
+export REDIS_CLOUD_API_SECRET="your-secret"
+
+# Use in commands (overrides config)
+redisctl cloud database list
+
+# Or reference in config
+cat > config.toml <<EOF
+[profiles.ci]
+deployment_type = "cloud"
+api_key = "\${REDIS_CLOUD_API_KEY}"
+api_secret = "\${REDIS_CLOUD_API_SECRET}"
+EOF
+```
+
+#### GitHub Actions Example
+```yaml
+- name: Deploy Database
+  env:
+    REDIS_CLOUD_API_KEY: ${{ secrets.REDIS_API_KEY }}
+    REDIS_CLOUD_API_SECRET: ${{ secrets.REDIS_API_SECRET }}
+  run: |
+    redisctl cloud database create \
+      --subscription-id 12345 \
+      --data @database.json \
+      --wait
+```
+
+## File Permissions
+
+Protect configuration files containing credentials:
+
+```bash
+# Restrict to owner only
+chmod 600 ~/.config/redisctl/config.toml
+
+# Verify permissions
+ls -la ~/.config/redisctl/config.toml
+# -rw------- 1 user user 1234 Jan 15 10:00 config.toml
+```
+
+## Credential Rotation
+
+### Regular Rotation Schedule
+
+1. **Generate new credentials** in Redis Cloud/Enterprise console
+2. **Update keyring** with new credentials:
+   ```bash
+   redisctl profile set production \
+     --api-key "new-key" \
+     --api-secret "new-secret" \
+     --use-keyring
+   ```
+3. **Test access** with new credentials
+4. **Revoke old credentials** in console
+
+### Automated Rotation Script
+```bash
+#!/bin/bash
+# rotate-credentials.sh
+
+PROFILE="production"
+NEW_KEY=$(generate-api-key)  # Your key generation method
+NEW_SECRET=$(generate-api-secret)
+
+# Update credentials
+redisctl profile set "$PROFILE" \
+  --api-key "$NEW_KEY" \
+  --api-secret "$NEW_SECRET" \
+  --use-keyring
+
+# Test new credentials
+if redisctl --profile "$PROFILE" cloud subscription list > /dev/null; then
+  echo "Credential rotation successful"
+  # Notify old credentials can be revoked
+else
+  echo "Credential rotation failed"
+  exit 1
+fi
+```
+
+## Secure Development Practices
+
+### Never Commit Credentials
+
+Add to `.gitignore`:
+```gitignore
+# Redis configuration
+~/.config/redisctl/config.toml
+.redisctl/
+*.secret
+*_credentials.toml
+```
+
+### Use Git Hooks
+
+Pre-commit hook to detect credentials:
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+
+# Check for API keys
+if git diff --cached | grep -E "api_key|api_secret|password" | grep -v "keyring:"; then
+  echo "ERROR: Potential credentials detected in commit"
+  echo "Use --use-keyring or environment variables instead"
+  exit 1
+fi
+```
+
+### Separate Development and Production
+
+Use different profiles for each environment:
+```toml
+# Development (with keyring for safety)
+[profiles.dev]
+deployment_type = "cloud"
+api_key = "keyring:dev-api-key"
+api_secret = "keyring:dev-api-secret"
+
+# Staging
+[profiles.staging]
+deployment_type = "cloud"
+api_key = "keyring:staging-api-key"
+api_secret = "keyring:staging-api-secret"
+
+# Production
+[profiles.production]
+deployment_type = "cloud"
+api_key = "keyring:production-api-key"
+api_secret = "keyring:production-api-secret"
+```
+
+## Audit and Monitoring
+
+### Profile Usage Audit
+
+Monitor which profiles are being used:
+```bash
+# Enable debug logging
+export RUST_LOG=debug
+
+# Commands will log profile usage
+redisctl --profile production cloud database list
+# [DEBUG] Using Redis Cloud profile: production
+```
+
+### Access Logging
+
+Create wrapper script for audit logging:
+```bash
+#!/bin/bash
+# /usr/local/bin/redisctl-audit
+
+# Log command execution
+echo "[$(date)] User: $USER, Command: redisctl $*" >> /var/log/redisctl-audit.log
+
+# Execute actual command
+exec /usr/local/bin/redisctl "$@"
+```
+
+### Credential Access Monitoring
+
+Monitor keyring access (macOS example):
+```bash
+# View keychain access logs
+log show --predicate 'subsystem == "com.apple.securityd"' --last 1h
+```
+
+## Network Security
+
+### TLS/SSL Verification
+
+Always verify SSL certificates in production:
+```toml
+[profiles.production]
+deployment_type = "enterprise"
+url = "https://cluster.example.com:9443"
+username = "admin@example.com"
+password = "keyring:production-password"
+insecure = false  # Never true in production
+```
+
+### IP Whitelisting
+
+Configure API access from specific IPs only:
+1. In Redis Cloud console, set IP whitelist
+2. In Redis Enterprise, configure firewall rules
+3. Document allowed IPs in team runbook
+
+## Incident Response
+
+### Compromised Credentials
+
+If credentials are compromised:
+
+1. **Immediately revoke** compromised credentials in console
+2. **Generate new credentials**
+3. **Update all systems** using the credentials:
+   ```bash
+   # Update all profiles using compromised credentials
+   for profile in $(redisctl profile list | grep production); do
+     redisctl profile set "$profile" \
+       --api-key "new-key" \
+       --api-secret "new-secret" \
+       --use-keyring
+   done
+   ```
+4. **Audit access logs** for unauthorized usage
+5. **Document incident** and update security procedures
+
+### Security Checklist
+
+- [ ] Using OS keyring for production credentials
+- [ ] Config files have restricted permissions (600)
+- [ ] Credentials not committed to version control
+- [ ] Environment variables used in CI/CD
+- [ ] Regular credential rotation scheduled
+- [ ] Audit logging enabled
+- [ ] SSL verification enabled
+- [ ] IP whitelisting configured
+- [ ] Incident response plan documented
+- [ ] Team trained on security procedures
+
+## Additional Resources
+
+- [Redis Security Documentation](https://redis.io/docs/manual/security/)
+- [Redis Cloud Security](https://redis.com/redis-enterprise-cloud/security/)
+- [Redis Enterprise Security](https://redis.com/redis-enterprise/security/)


### PR DESCRIPTION
Implements secure credential storage using OS keychain integration to address the security issue of storing credentials in plaintext config files.

- Added optional keyring crate dependency with 'secure-storage' feature flag
- Created credential storage abstraction layer with automatic keyring detection
- Added --use-keyring flag to profile set command
- Support for macOS Keychain, Windows Credential Store, Linux Secret Service
- Backwards compatible - existing plaintext configs continue to work

Fixes #180