### PR TITLE
fix: support both tag formats in release workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "redisctl-v*"
   workflow_dispatch:
 
 env:
@@ -32,6 +33,9 @@ jobs:
             if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
               # Running from a tag
               VERSION=${GITHUB_REF#refs/tags/v}
+            elif [[ "${{ github.ref }}" == refs/tags/redisctl-v* ]]; then
+              # Running from a redisctl-v tag
+              VERSION=${GITHUB_REF#refs/tags/redisctl-v}
             else
               # Running from a branch - extract version from Cargo.toml
               VERSION=$(grep '^version = ' crates/redisctl/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
@@ -39,7 +43,11 @@ jobs:
             fi
           else
             # Tag push event
-            VERSION=${GITHUB_REF#refs/tags/v}
+            if [[ "${{ github.ref }}" == refs/tags/redisctl-v* ]]; then
+              VERSION=${GITHUB_REF#refs/tags/redisctl-v}
+            else
+              VERSION=${GITHUB_REF#refs/tags/v}
+            fi
           fi
 
           # Validate version format

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "redisctl-v*"
   workflow_dispatch:
 
 env:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,121 @@
+# Release Process for redisctl
+
+This document outlines the complete release process to ensure all components are published correctly.
+
+## Overview
+
+A complete release includes:
+1. **GitHub Release** with binaries (handled by cargo-dist)
+2. **Docker Hub** image publication
+3. **crates.io** package publication
+
+## Release Steps
+
+### 1. Prepare the Release
+
+```bash
+# Ensure you're on main and up to date
+git checkout main
+git pull origin main
+
+# Update version in Cargo.toml files
+# Edit these files to update version (e.g., 0.6.1 -> 0.6.2):
+# - Cargo.toml (workspace.package.version)
+# - crates/redis-cloud/Cargo.toml
+# - crates/redis-enterprise/Cargo.toml
+# - crates/redisctl/Cargo.toml
+# Also update the dependency versions in crates/redisctl/Cargo.toml
+
+# Update CHANGELOG.md with release notes
+
+# Commit the changes
+git add -A
+git commit -m "chore: release vX.Y.Z"
+
+# Create a PR and merge it
+```
+
+### 2. Create and Push the Release Tag
+
+**IMPORTANT**: Use the `v` prefix format (not `redisctl-v`) for consistency:
+
+```bash
+# After PR is merged, pull latest main
+git checkout main
+git pull origin main
+
+# Create the release tag
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+
+# Push the tag - this triggers all workflows
+git push origin vX.Y.Z
+```
+
+### 3. Verify All Workflows Triggered
+
+The tag push should automatically trigger:
+
+1. **Release workflow** (cargo-dist): https://github.com/joshrotenberg/redisctl/actions/workflows/release.yml
+   - Creates GitHub release with binaries
+   - Takes ~10-15 minutes
+
+2. **Docker Build**: https://github.com/joshrotenberg/redisctl/actions/workflows/docker.yml
+   - Publishes to Docker Hub
+   - Takes ~5-10 minutes
+
+3. **Publish to crates.io**: https://github.com/joshrotenberg/redisctl/actions/workflows/publish-crates.yml
+   - Publishes all three crates
+   - Takes ~2-5 minutes
+
+### 4. Verify Release Components
+
+After workflows complete, verify:
+
+- [ ] GitHub Release: https://github.com/joshrotenberg/redisctl/releases
+  - Should have binaries for all platforms
+- [ ] Docker Hub: https://hub.docker.com/r/joshrotenberg/redisctl/tags
+  - Should have new version tag
+- [ ] crates.io: https://crates.io/crates/redisctl
+  - Should show new version
+
+## Troubleshooting
+
+### If Docker or crates.io workflows don't trigger:
+
+The workflows now support both `v*` and `redisctl-v*` tag formats. If they still don't trigger:
+
+1. **Manual trigger via GitHub UI**:
+   - Go to Actions tab
+   - Select the workflow (Docker Build or Publish to crates.io)
+   - Click "Run workflow"
+   - Select the tag or branch
+
+2. **Manual trigger via CLI**:
+   ```bash
+   gh workflow run "Docker Build" --ref vX.Y.Z
+   gh workflow run "Publish to crates.io" --ref vX.Y.Z
+   ```
+
+### If crates.io publish fails:
+
+Publish manually in order:
+```bash
+cd crates/redis-cloud && cargo publish
+cd ../redis-enterprise && cargo publish  
+cd ../redisctl && cargo publish
+```
+
+## Tag Format Standards
+
+Going forward, use the simpler `v` prefix format:
+- ✅ `v0.6.2`
+- ❌ `redisctl-v0.6.2` (avoid this)
+
+The workflows have been updated to support both formats for backward compatibility, but `v*` is preferred.
+
+## Automation Opportunities
+
+Consider adding:
+1. **release-plz** for automated version bumping and changelog generation
+2. **Unified release workflow** that ensures all three components are published
+3. **Release checklist GitHub Action** that validates all components were published


### PR DESCRIPTION
## Problem

Every release has been missing either Docker images or crates.io packages because the workflows only trigger on `v*` tags, but we've been creating `redisctl-v*` tags.

## Solution

1. **Updated workflows** to trigger on both tag formats:
   - `v*` (preferred going forward)
   - `redisctl-v*` (for compatibility)

2. **Added RELEASE.md** with comprehensive release process documentation

3. **Fixed version extraction** in Docker workflow to handle both formats

## Testing

For v0.6.2, we can now either:
- Create a `v0.6.2` tag (which will trigger everything)
- Or the existing `redisctl-v0.6.2` tag will work after this PR is merged

## Future Improvements

Consider:
- Adding release-plz for automated releases
- Creating a unified release workflow
- Standardizing on `v*` format only