### PR TITLE
feat: add automatic Homebrew formula updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - "**[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -277,6 +277,22 @@ jobs:
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+  update_brew_formula:
+    name: Update Brew Formula
+    runs-on: ubuntu-latest
+    needs: [plan, host]
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3.1
+        with:
+          formula-name: redisctl
+          formula-path: Formula/redisctl.rb
+          base-branch: main
+          tag-name: ${{ github.ref_name }}
+          homebrew-tap: joshrotenberg/homebrew-brew
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
   announce:
     needs:


### PR DESCRIPTION
Adds a workflow job to automatically update the Homebrew formula in joshrotenberg/homebrew-brew when a new release is published.

## Changes
- Added `update_brew_formula` job to `.github/workflows/release.yml`
- Job runs after GitHub release is created
- Uses `mislav/bump-homebrew-formula-action@v3.1` to update the formula
- Requires `COMMITTER_TOKEN` secret to be set

## Related
- Homebrew formula created in joshrotenberg/homebrew-brew
- Closes https://github.com/joshrotenberg/homebrew-brew/issues/2