### PR TITLE
fix: remove musl target from cargo-dist due to keyring incompatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+# Note: x86_64-unknown-linux-musl removed due to keyring incompatibility with musl
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether dist should create a Github Release or use an existing draft

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -66,6 +66,8 @@ full = ["cloud", "enterprise", "upload"]
 cloud = []
 enterprise = []
 upload = ["dep:files-sdk"]
+# Note: secure-storage may not work on musl targets due to keyring native dependencies
+# Build with --no-default-features --features full for musl
 secure-storage = ["dep:keyring"]
 
 [dev-dependencies]


### PR DESCRIPTION
## Issue

The v0.6.3 release failed on the x86_64-unknown-linux-musl build with OpenSSL linking errors.

## Root Cause

The `keyring` crate (used for secure credential storage) has native dependencies that don't work with musl libc. When building for musl, it tries to link against OpenSSL which isn't available in the cross-compilation environment.

## Solutions Considered

1. **Disable secure-storage for musl** - Complex cargo-dist configuration
2. **Vendor OpenSSL** - Increases build time and complexity significantly  
3. **Remove musl target** - Simplest solution (chosen)

## Trade-offs

- **Lost**: Static musl binaries (smaller, more portable)
- **Kept**: x86_64-unknown-linux-gnu binaries work on most Linux distributions
- **Workaround**: Users needing static builds can compile manually with `--no-default-features --features full`

## Impact

Most users won't notice - glibc binaries work on all major distributions. Only affects users specifically needing static musl binaries (Alpine Linux, minimal containers, etc.).

## Related

- Part of v0.6.3 release automation (#381, #332)
- Cargo-dist workflow: https://github.com/joshrotenberg/redisctl/actions/runs/18319509677