### PR TITLE
fix: remove unused variable warning on Windows builds

### DIFF
--- a/crates/redisctl/src/commands/enterprise/support_package.rs
+++ b/crates/redisctl/src/commands/enterprise/support_package.rs
@@ -396,16 +396,13 @@ fn perform_preflight_checks(output_path: &Path) -> AnyhowResult<()> {
     }
 
     // Check available disk space (warn if less than 1GB)
+    // Only perform check on Unix systems where we can read block count
+    #[cfg(unix)]
     if let Ok(metadata) = fs::metadata(parent_dir) {
-        // This is platform-specific and would need proper implementation
-        // For now, just a placeholder check
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt;
-            // Basic check - would need proper disk space checking
-            if metadata.blocks() < 1000000 {
-                eprintln!("Warning: Low disk space detected");
-            }
+        use std::os::unix::fs::MetadataExt;
+        // Basic check - would need proper disk space checking
+        if metadata.blocks() < 1000000 {
+            eprintln!("Warning: Low disk space detected");
         }
     }
 


### PR DESCRIPTION
## Issue

Fixes #382

Windows build was showing an unused variable warning because the `metadata` variable was only used inside a `#[cfg(unix)]` block.

## Fix

Moved the `#[cfg(unix)]` attribute to apply to the entire if statement, preventing the variable binding from being created on Windows.

## Before
```rust
if let Ok(metadata) = fs::metadata(parent_dir) {
    #[cfg(unix)]
    {
        // use metadata
    }
}
```

## After  
```rust
#[cfg(unix)]
if let Ok(metadata) = fs::metadata(parent_dir) {
    // use metadata
}
```

## Testing

This is a **test PR for our automated release workflow**. Once merged:
1. release-plz should create a version bump PR
2. Merging that PR should publish to crates.io and create a tag
3. Tag should trigger cargo-dist and Docker builds

Let's verify the end-to-end automation works!