### PR TITLE
fix: prevent duplicate release PRs with concurrency group

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release-plz
+  cancel-in-progress: false
+
 jobs:
   release-plz:
     name: Release-plz


### PR DESCRIPTION
## Problem

When merging a release PR, a race condition causes release-plz to create duplicate release PRs.

### The Race Condition

1. **Merge release PR** → triggers release-plz workflow (starts publishing to crates.io)
2. **Main branch updates** → triggers another release-plz workflow run
3. **Second run checks state** → doesn't see tags/releases yet (first run still publishing)
4. **Creates duplicate PR** → "Hey, we need to release this version!"

This happened with v0.6.5 where PR #392 was merged and immediately PR #396 was created for the same version.

## Solution

Add a concurrency group to the workflow to ensure only one release-plz run executes at a time:

```yaml
concurrency:
  group: release-plz
  cancel-in-progress: false  # Let the first run finish
```

With `cancel-in-progress: false`, the second workflow run will wait in queue until the first completes, by which time the tags/releases will exist and it will correctly determine no new release is needed.

## Testing

This fix will be validated on the next release cycle. We should see:
- ✅ Release PR merged
- ✅ Workflow publishes to crates.io
- ✅ Workflow creates tag and GitHub release
- ✅ Second workflow run skips (no changes needed)
- ❌ No duplicate release PR created